### PR TITLE
Add aspect screen features with textured buttons and rainbow maxed aspects

### DIFF
--- a/src/main/java/julianh06/wynnextras/features/aspects/AspectScreen.java
+++ b/src/main/java/julianh06/wynnextras/features/aspects/AspectScreen.java
@@ -1,0 +1,145 @@
+package julianh06.wynnextras.features.aspects;
+
+import com.wynntils.utils.colors.CustomColor;
+import julianh06.wynnextras.utils.UI.WEScreen;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.text.Text;
+
+import java.util.List;
+
+/**
+ * In-game GUI screen for viewing aspect loot pools
+ * Shows 4 raids side-by-side with their current loot pools
+ */
+public class AspectScreen extends WEScreen {
+
+    private static final int COLUMN_WIDTH = 280;
+    private static final int COLUMN_SPACING = 40;
+    private static final int HEADER_HEIGHT = 55;
+    private static final int ASPECT_LINE_HEIGHT = 22;
+
+    public AspectScreen() {
+        super(Text.of("WynnExtras Aspects"));
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+    }
+
+    @Override
+    protected void drawContent(DrawContext ctx, int mouseX, int mouseY, float tickDelta) {
+        int centerX = getLogicalWidth() / 2;
+        int startY = 120;
+
+        // Title
+        ui.drawCenteredText("ASPECT LOOT POOLS", centerX, 50, CustomColor.fromHexString("FFD700"), 10f);
+        ui.drawCenteredText("Weekly reset: Friday 19:00 CET", centerX, 80, CustomColor.fromHexString("AAAAAA"), 4f);
+
+        // Calculate starting X for 4 columns centered
+        int totalWidth = (COLUMN_WIDTH * 4) + (COLUMN_SPACING * 3);
+        int startX = (getLogicalWidth() - totalWidth) / 2;
+
+        // Draw each raid column
+        int col1X = startX;
+        int col2X = startX + (COLUMN_WIDTH + COLUMN_SPACING);
+        int col3X = startX + (COLUMN_WIDTH + COLUMN_SPACING) * 2;
+        int col4X = startX + (COLUMN_WIDTH + COLUMN_SPACING) * 3;
+
+        drawRaidColumn(ctx, col1X, startY, "NOTG", "Nest of the Grootslangs");
+        drawRaidColumn(ctx, col2X, startY, "NOL", "Orphion's Nexus of Light");
+        drawRaidColumn(ctx, col3X, startY, "TCC", "The Canyon Colossus");
+        drawRaidColumn(ctx, col4X, startY, "TNA", "The Nameless Anomaly");
+
+        // Instructions at bottom
+        drawInstructions(ctx, centerX, getLogicalHeight() - 60);
+    }
+
+    private void drawRaidColumn(DrawContext ctx, int x, int y, String raidCode, String raidName) {
+        LootPoolData data = LootPoolData.INSTANCE;
+        List<LootPoolData.AspectEntry> aspects = data.getLootPool(raidCode);
+
+        int panelHeight = getLogicalHeight() - y - 100;
+
+        // Background panel
+        ui.drawRect(x, y, COLUMN_WIDTH, panelHeight, CustomColor.fromHexString("1A1A1A"));
+        ui.drawRectBorders(x, y, COLUMN_WIDTH, panelHeight, CustomColor.fromHexString("4e392d"));
+
+        // Raid header
+        ui.drawCenteredText(raidCode, x + COLUMN_WIDTH / 2, y + 12, CustomColor.fromHexString("FFD700"), 7f);
+        ui.drawCenteredText(raidName, x + COLUMN_WIDTH / 2, y + 32, CustomColor.fromHexString("AAAAAA"), 3.5f);
+
+        // Separator line (aligned with panel edges)
+        ui.drawRect(x + 2, y + HEADER_HEIGHT, COLUMN_WIDTH - 4, 2, CustomColor.fromHexString("4e392d"));
+
+        int aspectY = y + HEADER_HEIGHT + 12;
+
+        if (aspects.isEmpty()) {
+            // No data yet
+            ui.drawCenteredText("No data", x + COLUMN_WIDTH / 2, aspectY + 40, CustomColor.fromHexString("666666"), 5f);
+            ui.drawCenteredText("Open the", x + COLUMN_WIDTH / 2, aspectY + 65, CustomColor.fromHexString("666666"), 3.5f);
+            ui.drawCenteredText("preview chest", x + COLUMN_WIDTH / 2, aspectY + 82, CustomColor.fromHexString("666666"), 3.5f);
+            ui.drawCenteredText("to scan aspects", x + COLUMN_WIDTH / 2, aspectY + 99, CustomColor.fromHexString("666666"), 3.5f);
+        } else {
+            // Draw aspects grouped by rarity
+            aspectY = drawAspectsByRarity(ctx, x, aspectY, aspects, "Mythic", "★");
+            aspectY = drawAspectsByRarity(ctx, x, aspectY, aspects, "Fabled", "◇");
+            aspectY = drawAspectsByRarity(ctx, x, aspectY, aspects, "Legendary", "◆");
+        }
+    }
+
+    private int drawAspectsByRarity(DrawContext ctx, int x, int y, List<LootPoolData.AspectEntry> aspects, String rarity, String symbol) {
+        // Filter aspects by rarity
+        List<LootPoolData.AspectEntry> filtered = aspects.stream()
+            .filter(a -> a.rarity.equalsIgnoreCase(rarity))
+            .toList();
+
+        if (filtered.isEmpty()) {
+            return y;
+        }
+
+        // Get color for rarity
+        CustomColor color = getRarityColor(rarity);
+
+        // Draw each aspect
+        for (LootPoolData.AspectEntry aspect : filtered) {
+            String displayName = aspect.name;
+
+            // Shorten long names to fit column
+            if (displayName.length() > 32) {
+                displayName = displayName.substring(0, 29) + "...";
+            }
+
+            ui.drawText(symbol + " " + displayName, x + 10, y, color, 4f);
+            y += ASPECT_LINE_HEIGHT;
+        }
+
+        // Add spacing after each rarity group
+        y += 8;
+
+        return y;
+    }
+
+    private CustomColor getRarityColor(String rarity) {
+        return switch (rarity.toLowerCase()) {
+            case "mythic" -> CustomColor.fromHexString("AA00AA"); // Dark purple
+            case "fabled" -> CustomColor.fromHexString("FF5555"); // Red
+            case "legendary" -> CustomColor.fromHexString("55FFFF"); // Light blue
+            default -> CustomColor.fromHexString("FFFFFF"); // White
+        };
+    }
+
+    private void drawInstructions(DrawContext ctx, int centerX, int y) {
+        ui.drawCenteredText("Open raid preview chests to automatically scan and save loot pools", centerX, y, CustomColor.fromHexString("AAAAAA"), 3.5f);
+        ui.drawCenteredText("Switch raids inside the chest to scan all 4 pools", centerX, y + 18, CustomColor.fromHexString("AAAAAA"), 3.5f);
+    }
+
+    @Override
+    public void updateValues() {
+        // No dynamic sizing needed for now
+    }
+
+    public static void open() {
+        WEScreen.open(AspectScreen::new);
+    }
+}

--- a/src/main/java/julianh06/wynnextras/features/aspects/AspectScreenSimple.java
+++ b/src/main/java/julianh06/wynnextras/features/aspects/AspectScreenSimple.java
@@ -1,0 +1,3815 @@
+package julianh06.wynnextras.features.aspects;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.wynntils.core.text.StyledText;
+import com.wynntils.utils.colors.CommonColors;
+import com.wynntils.utils.colors.CustomColor;
+import com.wynntils.utils.mc.McUtils;
+import com.wynntils.utils.render.FontRenderer;
+import com.wynntils.utils.render.type.HorizontalAlignment;
+import com.wynntils.utils.render.type.TextShadow;
+import com.wynntils.utils.render.type.VerticalAlignment;
+import julianh06.wynnextras.core.WynnExtras;
+import julianh06.wynnextras.features.profileviewer.WynncraftApiHandler;
+import julianh06.wynnextras.features.profileviewer.data.ApiAspect;
+import julianh06.wynnextras.features.profileviewer.data.Aspect;
+import julianh06.wynnextras.features.profileviewer.data.User;
+import julianh06.wynnextras.features.raid.RaidData;
+import julianh06.wynnextras.features.raid.RaidListData;
+import julianh06.wynnextras.features.raid.RaidLootConfig;
+import julianh06.wynnextras.features.raid.RaidLootData;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.minecraft.client.MinecraftClient;
+import julianh06.wynnextras.utils.UI.WEScreen;
+import net.minecraft.client.gui.Click;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.input.CharInput;
+import net.minecraft.client.input.KeyInput;
+import net.minecraft.client.util.InputUtil;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.CustomModelDataComponent;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.registry.Registries;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.time.format.TextStyle;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.wynntils.utils.wynn.ContainerUtils.clickOnSlot;
+
+/**
+ * Simple custom screen for viewing aspect loot pools and gambits
+ * Page 0: Loot Pools (4 raids) - auto-navigates to party finder when clicking raid
+ * Page 1: Gambits (today's 4 gambits + countdown)
+ * Page 2: My Aspects (player's own aspects from API)
+ */
+public class AspectScreenSimple extends WEScreen {
+
+    private int currentPage = 0; // 0 = Loot Pools, 1 = Gambits, 2 = My Aspects, 3 = Raid Loot, 4 = Explore, 5 = Leaderboard
+    private static final int MAX_PAGE = 5; // 6 pages total
+
+    // For tooltips
+    private LootPoolData.AspectEntry hoveredAspect = null;
+    private int hoveredAspectX = 0;
+    private int hoveredAspectY = 0;
+    private int hoveredAspectColumnX = 0; // Track which column the hovered aspect is in
+
+    // For My Aspects page
+    private User myAspectsData = null;
+    private WynncraftApiHandler.FetchStatus myAspectsFetchStatus = null;
+    private boolean fetchedMyAspects = false;
+    private int myAspectsFetchGeneration = 0; // Track which fetch is current
+
+    // Filters for My Aspects page
+    private String classFilter = "Warrior"; // Default to Warrior, no "All" mode
+    private String maxFilter = "All"; // All, Max Only, Not Max, Favorites
+    private boolean showOverview = true; // Toggle between class view and overview - default to overview
+
+    // Player search for My Aspects page
+    private String searchedPlayer = ""; // Empty = show own aspects
+    private User searchedPlayerData = null;
+    private WynncraftApiHandler.FetchStatus searchedPlayerStatus = null;
+
+    // Text input for player search
+    private String searchInput = "";
+    private boolean searchInputFocused = false;
+    private int searchCursorPos = 0;
+    // Recent searches are stored in FavoriteAspectsData for persistence
+    private static final int MAX_RECENT_SEARCHES = 5;
+
+    // Filter for Loot Pools page
+    private boolean hideMaxInLootPools = false; // Hide maxed aspects in loot pools
+    private boolean showOnlyFavoritesInLootPools = false; // Show only favorite aspects in loot pools
+    private int exploreSortMode = 0; // 0 = Most Max Aspects, 1 = Username
+
+    // Progress bar mode: true = show "max" counts, false = show "unlocked" counts
+    private boolean progressBarShowMax = true;
+
+    // Scroll offsets for each raid column (NOTG, NOL, TCC, TNA)
+    private int[] raidScrollOffsets = new int[4];
+    private int[] raidContentHeights = new int[4]; // Track content height for each column
+    private int[] raidColumnX = new int[4]; // X positions of each column
+    private int[] raidColumnWidth = new int[4]; // Width of each column
+    private int raidContentStartY = 0; // Y position where content starts (below header)
+    private int raidPanelHeight = 0; // Height of the content area
+
+    // For party finder auto-navigation
+    private static String pendingRaidJoin = null;
+
+    // Debug mode for showing raid slots
+    public static boolean debugMode = false;
+
+    // Hovering for my aspects
+    private ApiAspect hoveredMyAspect = null;
+    private Aspect hoveredMyAspectProgress = null;
+
+    // For Raid Loot page (page 3)
+    private boolean[] raidToggles = {true, true, true, true}; // NOTG, NOL, TCC, TNA
+    private boolean showRates = false; // Toggle between totals and averages
+
+    // For Explore page (page 4)
+    private List<julianh06.wynnextras.features.profileviewer.data.PlayerListEntry> playerList = null;
+    private boolean fetchedPlayerList = false;
+
+    // For Leaderboard page (page 5)
+    private List<julianh06.wynnextras.features.profileviewer.data.LeaderboardEntry> leaderboardList = null;
+    private boolean fetchedLeaderboard = false;
+
+    // For Gambits page (page 2) - crowdsourced data
+    private List<julianh06.wynnextras.features.aspects.GambitData.GambitEntry> crowdsourcedGambits = null;
+    private boolean fetchedCrowdsourcedGambits = false;
+
+    // For Loot Pools page (page 0) - crowdsourced data per raid
+    private java.util.Map<String, List<julianh06.wynnextras.features.aspects.LootPoolData.AspectEntry>> crowdsourcedLootPools = new java.util.HashMap<>();
+    private boolean fetchedCrowdsourcedLootPools = false;
+
+    // Player's personal aspect progress (name -> amount + rarity)
+    private java.util.Map<String, com.mojang.datafixers.util.Pair<Integer, String>> personalAspectProgress = new java.util.HashMap<>();
+    private boolean fetchedPersonalProgress = false;
+
+    public AspectScreenSimple() {
+        super(Text.of("WynnExtras Aspects"));
+    }
+
+    // For showing import result feedback
+    private String importFeedback = null;
+    private long importFeedbackTime = 0;
+
+    // ===== TEXT RENDERING HELPERS (using WEScreen UIUtils) =====
+
+    private void drawCenteredText(DrawContext context, String text, int x, int y) {
+        if (ui != null) {
+            ui.drawCenteredText(text, x, y, CustomColor.fromInt(0xFFFFFF), 3f);
+        }
+    }
+
+    private void drawLeftText(DrawContext context, String text, int x, int y) {
+        if (ui != null) {
+            ui.drawText(text, x, y, CustomColor.fromInt(0xFFFFFF), 3f);
+        }
+    }
+
+    /**
+     * Calculate a safe column width based on logical screen width
+     */
+    private int getSafeColumnWidth(int numColumns, int spacing) {
+        int margin = 40;
+        int availableWidth = getLogicalWidth() - (margin * 2);
+        int totalSpacing = spacing * (numColumns - 1);
+        int calculatedWidth = (availableWidth - totalSpacing) / numColumns;
+        return Math.max(350, calculatedWidth);
+    }
+
+    /**
+     * Get aspect spacing in logical units
+     */
+    private int getAspectSpacing() {
+        return 40;
+    }
+
+    /**
+     * Get panel bottom margin for raid columns in logical units
+     */
+    private int getRaidPanelBottomMargin() {
+        return 200;
+    }
+
+    /**
+     * Get panel bottom margin for class columns in logical units
+     */
+    private int getClassPanelBottomMargin() {
+        return 150;
+    }
+
+    /**
+     * Get starting Y position for loot pools/raid columns in logical units
+     */
+    private int getLootPoolStartY() {
+        return 180;
+    }
+
+    /**
+     * Get filter button Y position in logical units
+     */
+    private int getFilterButtonY() {
+        return 160;
+    }
+
+    /**
+     * Get starting Y position for My Aspects page - consistent in logical units
+     */
+    private int getMyAspectsStartY() {
+        return 220; // Consistent in logical units
+    }
+
+    /**
+     * Helper to draw a filled rectangle using UIUtils
+     */
+    private void drawRect(int x, int y, int width, int height, int color) {
+        if (ui != null) {
+            // Extract alpha and RGB from ARGB color
+            float alpha = ((color >> 24) & 0xFF) / 255f;
+            int rgb = color & 0xFFFFFF;
+            ui.drawRect(x, y, width, height, CustomColor.fromInt(rgb).withAlpha(alpha));
+        }
+    }
+
+    @Override
+    protected void drawContent(DrawContext context, int mouseX, int mouseY, float delta) {
+        // WEScreen handles background
+
+        // Draw "WYNNEXTRAS" in bold dark green at the very top center
+        int centerX = getLogicalWidth() / 2;
+        drawCenteredText(context, "§2§lWYNNEXTRAS", centerX, 20);
+
+        // Convert mouse coords to logical
+        int logicalMouseX = (int)(mouseX * scaleFactor);
+        int logicalMouseY = (int)(mouseY * scaleFactor);
+
+        // Draw "Import Wynntils Favorites" button on Loot Pools and My Aspects pages (top left)
+        if (currentPage == 0 || currentPage == 1) {
+            drawImportWynntilsButton(context, logicalMouseX, logicalMouseY);
+        }
+
+        if (currentPage == 0) {
+            renderLootPoolsPage(context, mouseX, mouseY);
+        } else if (currentPage == 1) {
+            renderMyAspectsPage(context, mouseX, mouseY);
+        } else if (currentPage == 2) {
+            renderGambitsPage(context, mouseX, mouseY);
+        } else if (currentPage == 3) {
+            renderRaidLootPage(context, mouseX, mouseY);
+        } else if (currentPage == 4) {
+            renderExplorePage(context, mouseX, mouseY);
+        } else if (currentPage == 5) {
+            renderLeaderboardPage(context, mouseX, mouseY);
+        }
+
+        // Page indicator and arrows (on top)
+        renderNavigation(context, mouseX, mouseY);
+
+        // Render tooltip if hovering over aspect
+        if (hoveredAspect != null) {
+            renderAspectTooltip(context, mouseX, mouseY);
+        }
+    }
+
+    private void renderLootPoolsPage(DrawContext context, int mouseX, int mouseY) {
+        // Reset hovered aspect at start of frame
+        hoveredAspect = null;
+
+        int logicalW = getLogicalWidth();
+        int logicalH = getLogicalHeight();
+        int centerX = logicalW / 2;
+
+        // Fetch crowdsourced loot pools from API on first load
+        if (!fetchedCrowdsourcedLootPools) {
+            fetchedCrowdsourcedLootPools = true;
+            String[] raids = {"NOTG", "NOL", "TCC", "TNA"};
+            for (String raidType : raids) {
+                WynncraftApiHandler.fetchCrowdsourcedLootPool(raidType).thenAccept(result -> {
+                    if (result != null && !result.isEmpty()) {
+                        crowdsourcedLootPools.put(raidType, result);
+                        System.out.println("[WynnExtras] Fetched " + result.size() + " crowdsourced aspects for " + raidType);
+                        // Save to local data for offline access
+                        julianh06.wynnextras.features.aspects.LootPoolData.INSTANCE.saveLootPoolFull(raidType, result);
+                    } else {
+                        System.out.println("[WynnExtras] No crowdsourced loot pool for " + raidType);
+                    }
+                });
+            }
+        }
+
+        // Fetch player's personal aspect progress for overlay
+        if (!fetchedPersonalProgress && McUtils.player() != null) {
+            fetchedPersonalProgress = true;
+            String playerUUID = McUtils.player().getUuidAsString();
+            WynncraftApiHandler.fetchPlayerAspectData(playerUUID, playerUUID).thenAccept(result -> {
+                if (result != null && result.status() == WynncraftApiHandler.FetchStatus.OK && result.user() != null) {
+                    julianh06.wynnextras.features.profileviewer.data.User userData = result.user();
+                    // Convert aspect data to progress map (name -> (amount, rarity))
+                    java.util.List<julianh06.wynnextras.features.profileviewer.data.Aspect> aspects = userData.getAspects();
+                    if (aspects != null) {
+                        for (julianh06.wynnextras.features.profileviewer.data.Aspect aspect : aspects) {
+                            personalAspectProgress.put(aspect.getName(),
+                                new com.mojang.datafixers.util.Pair<>(aspect.getAmount(), aspect.getRarity()));
+                        }
+                        System.out.println("[WynnExtras] Fetched personal progress for " + personalAspectProgress.size() + " aspects");
+                    }
+                }
+            });
+        }
+
+        // Title
+        drawCenteredText(context, "§6§lASPECT LOOT POOLS", centerX, 60);
+
+        // Calculate next Friday 19:00 CET
+        ZonedDateTime now = ZonedDateTime.now(ZoneId.of("CET"));
+        ZonedDateTime nextReset = now.with(java.time.DayOfWeek.FRIDAY).withHour(19).withMinute(0).withSecond(0).withNano(0);
+        if (nextReset.isBefore(now) || nextReset.isEqual(now)) {
+            nextReset = nextReset.plusWeeks(1);
+        }
+
+        // Calculate time difference
+        Duration duration = Duration.between(now, nextReset);
+        long days = duration.toDays();
+        long hours = duration.toHours() % 24;
+        long minutes = duration.toMinutes() % 60;
+
+        // Format as "Friday (in xx days xx hours xx minutes)"
+        String countdown = String.format("Friday (in §e%d§7 days §e%d§7 hours §e%d§7 minutes)", days, hours, minutes);
+        drawCenteredText(context, "§7Weekly reset: " + countdown, centerX, 110);
+
+        // Toggle buttons (in logical coords)
+        int toggleWidth = 200;
+        int favToggleWidth = 260; // Wider for favorites
+        int toggleHeight = 44;
+        int toggleSpacing = 15;
+        int toggleY = 14;
+        // Convert mouse to logical for hover check
+        int logicalMouseX = (int)(mouseX * scaleFactor);
+        int logicalMouseY = (int)(mouseY * scaleFactor);
+
+        // Favorite toggle (left of Hide Max)
+        int favToggleX = logicalW - toggleWidth - favToggleWidth - toggleSpacing - 60;
+        boolean hoverFavToggle = logicalMouseX >= favToggleX && logicalMouseX <= favToggleX + favToggleWidth && logicalMouseY >= toggleY && logicalMouseY <= toggleY + toggleHeight;
+
+        // Draw textured button
+        if (ui != null) {
+            ui.drawButtonFade(favToggleX, toggleY, favToggleWidth, toggleHeight, 12, hoverFavToggle || showOnlyFavoritesInLootPools);
+        }
+
+        String favToggleText = showOnlyFavoritesInLootPools ? "§e§l⭐ Favorites Only" : "§7§l☆ Favorites Only";
+        drawCenteredText(context, favToggleText, favToggleX + favToggleWidth / 2, toggleY + toggleHeight / 2);
+
+        // Hide Max toggle button
+        int toggleX = logicalW - toggleWidth - 60;
+        boolean hoverToggle = logicalMouseX >= toggleX && logicalMouseX <= toggleX + toggleWidth && logicalMouseY >= toggleY && logicalMouseY <= toggleY + toggleHeight;
+
+        // Draw textured button
+        if (ui != null) {
+            ui.drawButtonFade(toggleX, toggleY, toggleWidth, toggleHeight, 12, hoverToggle || hideMaxInLootPools);
+        }
+
+        String toggleText = hideMaxInLootPools ? "§6§lShow Max" : "§7§lHide Max";
+        drawCenteredText(context, toggleText, toggleX + toggleWidth / 2, toggleY + toggleHeight / 2);
+
+        // 4 columns for raids - using logical dimensions
+        int startY = getLootPoolStartY();
+        int columnSpacing = 30; // Spacing in logical units
+        int columnWidth = getSafeColumnWidth(4, columnSpacing);
+        int totalWidth = (columnWidth * 4) + (columnSpacing * 3);
+        int startX = (logicalW - totalWidth) / 2;
+
+        String[] raids = {"NOTG", "NOL", "TCC", "TNA"};
+        String[] raidNames = {
+            "Nest of the Grootslangs",
+            "Orphion's Nexus of Light",
+            "The Canyon Colossus",
+            "The Nameless Anomaly"
+        };
+
+        // Calculate aligned separator positions
+        int[] rarityMaxCounts = calculateMaxRarityCounts(raids);
+        int spacing = getAspectSpacing();
+        int mythicSeparatorY = startY + 150 + (rarityMaxCounts[0] * spacing) + 10;
+        int fabledSeparatorY = mythicSeparatorY + (rarityMaxCounts[1] * spacing) + 25;
+
+        // Store column info for scroll detection (in logical coords)
+        raidContentStartY = startY + 150; // Content starts below header
+        raidPanelHeight = logicalH - startY - getRaidPanelBottomMargin() - 150; // Content area height
+
+        // FIRST PASS: Check hover for all columns before any drawing
+        // This ensures hoveredAspect is set correctly before we draw
+        for (int i = 0; i < 4; i++) {
+            int x = startX + (i * (columnWidth + columnSpacing));
+            raidColumnX[i] = x;
+            raidColumnWidth[i] = columnWidth;
+            checkRaidColumnHover(x, startY, raids[i], columnWidth, logicalMouseX, logicalMouseY, mythicSeparatorY, fabledSeparatorY, i);
+        }
+
+        // SECOND PASS: Draw all columns (now hoveredAspect is already set correctly)
+        for (int i = 0; i < 4; i++) {
+            int x = startX + (i * (columnWidth + columnSpacing));
+            drawRaidColumn(context, x, startY, raids[i], raidNames[i], columnWidth, logicalMouseX, logicalMouseY, mythicSeparatorY, fabledSeparatorY, i);
+        }
+
+        // Instructions above navigation - only show if no data
+        boolean hasAnyData = LootPoolData.INSTANCE.hasData("NOTG") || LootPoolData.INSTANCE.hasData("NOL")
+                          || LootPoolData.INSTANCE.hasData("TCC") || LootPoolData.INSTANCE.hasData("TNA");
+        if (!hasAnyData) {
+            drawCenteredText(context, "§7Open raid preview chests to scan loot pools", centerX, logicalH - 165);
+        }
+    }
+
+    /**
+     * Calculate maximum count for each rarity across all raids
+     * Returns [mythicMax, fabledMax, legendaryMax]
+     */
+    /**
+     * Get loot pool for a raid, prioritizing crowdsourced data over local data
+     * Overlays player's personal progress on crowdsourced aspects
+     */
+    private List<LootPoolData.AspectEntry> getLootPoolForRaid(String raidCode) {
+        // Use crowdsourced data if available
+        if (crowdsourcedLootPools.containsKey(raidCode)) {
+            List<LootPoolData.AspectEntry> crowdsourced = crowdsourcedLootPools.get(raidCode);
+            if (crowdsourced != null && !crowdsourced.isEmpty()) {
+                // Overlay personal progress on crowdsourced data
+                List<LootPoolData.AspectEntry> withProgress = new java.util.ArrayList<>();
+                for (LootPoolData.AspectEntry aspect : crowdsourced) {
+                    // Check if we have personal progress for this aspect
+                    if (personalAspectProgress.containsKey(aspect.name)) {
+                        com.mojang.datafixers.util.Pair<Integer, String> progress = personalAspectProgress.get(aspect.name);
+                        int amount = progress.getFirst();
+                        String rarity = progress.getSecond();
+
+                        // Convert amount to tier info string
+                        String tierInfo = convertAmountToTierInfo(amount, rarity);
+
+                        // Create new entry with personal tier info
+                        withProgress.add(new LootPoolData.AspectEntry(aspect.name, rarity, tierInfo, aspect.description));
+                    } else {
+                        // No personal data, use crowdsourced as-is (will show without tier)
+                        withProgress.add(aspect);
+                    }
+                }
+                return withProgress;
+            }
+        }
+        // Fall back to local data
+        return LootPoolData.INSTANCE.getLootPool(raidCode);
+    }
+
+    /**
+     * Convert aspect amount to tier info display string
+     * Reverse of parseAspectAmount logic
+     */
+    private String convertAmountToTierInfo(int amount, String rarity) {
+        int[] tier1 = {1, 1, 1};
+        int[] tier2 = {4, 14, 4};
+        int[] tier3 = {10, 60, 25};
+        int[] tier4 = {0, 0, 120};
+
+        int rarityIndex;
+        switch (rarity) {
+            case "Mythic" -> rarityIndex = 0;
+            case "Fabled" -> rarityIndex = 1;
+            case "Legendary" -> rarityIndex = 2;
+            default -> {
+                return "";
+            }
+        }
+
+        int maxAmount = tier1[rarityIndex] + tier2[rarityIndex] + tier3[rarityIndex] + tier4[rarityIndex];
+        if (amount >= maxAmount) {
+            return "[MAX]";
+        }
+
+        int tier1Total = tier1[rarityIndex];
+        int tier2Total = tier1Total + tier2[rarityIndex];
+        int tier3Total = tier2Total + tier3[rarityIndex];
+
+        if (amount < tier1Total) {
+            return "Tier I [" + amount + "/" + tier1[rarityIndex] + "]";
+        } else if (amount < tier2Total) {
+            int progress = amount - tier1Total;
+            return "Tier II [" + progress + "/" + tier2[rarityIndex] + "]";
+        } else if (amount < tier3Total) {
+            int progress = amount - tier2Total;
+            return "Tier III [" + progress + "/" + tier3[rarityIndex] + "]";
+        } else {
+            int progress = amount - tier3Total;
+            return "Tier IV [" + progress + "/" + tier4[rarityIndex] + "]";
+        }
+    }
+
+    private int[] calculateMaxRarityCounts(String[] raids) {
+        int maxMythic = 0;
+        int maxFabled = 0;
+        int maxLegendary = 0;
+
+        for (String raid : raids) {
+            List<LootPoolData.AspectEntry> aspects = getLootPoolForRaid(raid);
+
+            int mythicCount = (int) aspects.stream().filter(a -> a.rarity.equalsIgnoreCase("Mythic")).count();
+            int fabledCount = (int) aspects.stream().filter(a -> a.rarity.equalsIgnoreCase("Fabled")).count();
+            int legendaryCount = (int) aspects.stream().filter(a -> a.rarity.equalsIgnoreCase("Legendary")).count();
+
+            maxMythic = Math.max(maxMythic, mythicCount);
+            maxFabled = Math.max(maxFabled, fabledCount);
+            maxLegendary = Math.max(maxLegendary, legendaryCount);
+        }
+
+        return new int[]{maxMythic, maxFabled, maxLegendary};
+    }
+
+    private void drawRaidColumn(DrawContext context, int x, int y, String raidCode, String raidName, int colWidth, int mouseX, int mouseY, int mythicSeparatorY, int fabledSeparatorY, int raidIndex) {
+        int logicalH = getLogicalHeight();
+        int panelHeight = logicalH - y - getRaidPanelBottomMargin();
+
+        // Background box (using UIUtils for proper scaling)
+        drawRect(x, y, colWidth, panelHeight, 0xAA000000);
+
+        // Border
+        drawRect(x, y, colWidth, 6, 0xFF4e392d); // Top
+        drawRect(x, y + panelHeight - 6, colWidth, 6, 0xFF4e392d); // Bottom
+        drawRect(x, y, 6, panelHeight, 0xFF4e392d); // Left
+        drawRect(x + colWidth - 6, y, 6, panelHeight, 0xFF4e392d); // Right
+
+        // Check if hovering over raid header (mouseX/Y are already in logical coords)
+        int headerHeight = 120;
+        boolean hoveringHeader = mouseX >= x && mouseX <= x + colWidth &&
+                                 mouseY >= y && mouseY <= y + headerHeight;
+
+        // Raid header (centered)
+        drawCenteredText(context, "§6§l" + raidCode, x + colWidth / 2, y + 25);
+        drawCenteredText(context, "§7" + truncate(raidName, 30), x + colWidth / 2, y + 65);
+
+        // Get aspects (prioritize crowdsourced data)
+        List<LootPoolData.AspectEntry> aspects = getLootPoolForRaid(raidCode);
+        boolean usingCrowdsourced = crowdsourcedLootPools.containsKey(raidCode) &&
+                                     crowdsourcedLootPools.get(raidCode) != null &&
+                                     !crowdsourcedLootPools.get(raidCode).isEmpty();
+
+        // Calculate and show score
+        double score = calculateRaidScore(aspects);
+        // Check if all aspects are actually maxed (have valid tierInfo that indicates max)
+        boolean allMaxed = !aspects.isEmpty() && aspects.stream().allMatch(a ->
+            a.tierInfo != null && (a.tierInfo.isEmpty() || a.tierInfo.contains("[MAX]"))
+        );
+        if (allMaxed && ui != null) {
+            // Rainbow text for MAXED
+            ui.drawCenteredText("MAXED", x + colWidth / 2, y + 100, CommonColors.RAINBOW, 3f);
+        } else {
+            String scoreText = String.format("§7Score: §e%.2f", score);
+            drawCenteredText(context, scoreText, x + colWidth / 2, y + 100);
+        }
+
+        // Show data source indicator
+        if (!aspects.isEmpty()) {
+            String dataSource = usingCrowdsourced ? "§a§o(Crowdsourced)" : "§e§o(Local)";
+            drawCenteredText(context, dataSource, x + colWidth / 2, y + 120);
+        }
+
+        // Separator line (more space below score)
+        drawRect(x + 12, y + 135, colWidth - 24, 6, 0xFF4e392d);
+
+        // Render tooltip if hovering (convert back to screen coords for tooltip)
+        if (hoveringHeader && ui != null) {
+            List<Text> tooltip = new ArrayList<>();
+            tooltip.add(Text.literal("§6§l" + raidCode));
+            tooltip.add(Text.literal("§7" + raidName));
+            tooltip.add(Text.literal(""));
+            tooltip.add(Text.literal("§7Score: §e" + String.format("%.2f", score)));
+            tooltip.add(Text.literal("§8(Favorites count 3x)"));
+            tooltip.add(Text.literal(""));
+            tooltip.add(Text.literal("§aClick to join party finder"));
+            context.drawTooltip(textRenderer, tooltip, (int)ui.sx(mouseX), (int)ui.sy(mouseY));
+        }
+
+        int contentStartY = y + 150; // Where content starts (below header)
+        int contentHeight = panelHeight - 150 - 12; // Available height for content
+        int scrollOffset = raidScrollOffsets[raidIndex];
+
+        if (aspects.isEmpty()) {
+            drawCenteredText(context, "§7No data", x + colWidth / 2, contentStartY + 60);
+            drawCenteredText(context, "§7Open preview", x + colWidth / 2, contentStartY + 110);
+            drawCenteredText(context, "§7chest to scan", x + colWidth / 2, contentStartY + 160);
+            raidContentHeights[raidIndex] = 0; // No scrollable content
+        } else {
+            // Calculate total content height first
+            int totalContentHeight = calculateTotalContentHeight(aspects);
+            raidContentHeights[raidIndex] = totalContentHeight;
+
+            // Clamp scroll offset
+            int maxScroll = Math.max(0, totalContentHeight - contentHeight);
+            if (scrollOffset > maxScroll) {
+                raidScrollOffsets[raidIndex] = maxScroll;
+                scrollOffset = maxScroll;
+            }
+            if (scrollOffset < 0) {
+                raidScrollOffsets[raidIndex] = 0;
+                scrollOffset = 0;
+            }
+
+            // Enable scissor to clip content to panel area (convert to screen coords)
+            if (ui != null) {
+                context.enableScissor(
+                    (int)ui.sx(x + 6),
+                    (int)ui.sy(contentStartY - 12),
+                    (int)ui.sx(x + colWidth - 6),
+                    (int)ui.sy(contentStartY + contentHeight)
+                );
+            }
+
+            // Apply scroll offset to content Y (start 12px lower to give room for first flame)
+            int textY = contentStartY + 12 - scrollOffset;
+
+            // Draw aspects by rarity (hover is already checked in pre-pass)
+            textY = drawAspectsByRarity(context, x, textY, aspects, "Mythic", "", "§5", colWidth);
+
+            // Draw separator line after mythic (adjusted for scroll)
+            int adjustedMythicSepY = mythicSeparatorY - scrollOffset;
+            if (adjustedMythicSepY >= contentStartY && adjustedMythicSepY <= contentStartY + contentHeight) {
+                drawRect(x + 24, adjustedMythicSepY, colWidth - 48, 3, 0xFF4e392d);
+            }
+            textY = mythicSeparatorY + 20 - scrollOffset; // Position for fabled start
+
+            textY = drawAspectsByRarity(context, x, textY, aspects, "Fabled", "", "§c", colWidth);
+
+            // Draw separator line after fabled (adjusted for scroll)
+            int adjustedFabledSepY = fabledSeparatorY - scrollOffset;
+            if (adjustedFabledSepY >= contentStartY && adjustedFabledSepY <= contentStartY + contentHeight) {
+                drawRect(x + 24, adjustedFabledSepY, colWidth - 48, 3, 0xFF4e392d);
+            }
+            textY = fabledSeparatorY + 20 - scrollOffset; // Position for legendary start
+
+            textY = drawAspectsByRarity(context, x, textY, aspects, "Legendary", "", "§b", colWidth);
+
+            // Disable scissor
+            context.disableScissor();
+
+            // Draw scroll bar if content is scrollable
+            if (totalContentHeight > contentHeight) {
+                drawScrollBar(context, x + colWidth - 18, contentStartY, 12, contentHeight, scrollOffset, totalContentHeight);
+            }
+        }
+    }
+
+    /**
+     * Pre-pass to check hover state for a raid column before drawing
+     * This ensures hoveredAspect is set before any column is drawn
+     */
+    private void checkRaidColumnHover(int x, int y, String raidCode, int colWidth, int mouseX, int mouseY, int mythicSeparatorY, int fabledSeparatorY, int raidIndex) {
+        int logicalH = getLogicalHeight();
+        int panelHeight = logicalH - y - getRaidPanelBottomMargin();
+
+        // Get aspects (same logic as drawRaidColumn)
+        List<LootPoolData.AspectEntry> aspects = getLootPoolForRaid(raidCode);
+
+        if (!aspects.isEmpty()) {
+            int contentStartY = y + 150;
+            int contentHeight = panelHeight - 150 - 10;
+            int scrollOffset = raidScrollOffsets[raidIndex];
+
+            // Check hover for all rarities
+            checkAspectHover(mouseX, mouseY, x, contentStartY + 12 - scrollOffset, aspects, "Mythic", "", colWidth);
+
+            int fabledY = mythicSeparatorY + 20;
+            checkAspectHover(mouseX, mouseY, x, fabledY - scrollOffset, aspects, "Fabled", "", colWidth);
+
+            int legendaryY = fabledSeparatorY + 20;
+            checkAspectHover(mouseX, mouseY, x, legendaryY - scrollOffset, aspects, "Legendary", "", colWidth);
+        }
+    }
+
+    /**
+     * Calculate total content height for a raid column
+     */
+    private int calculateTotalContentHeight(List<LootPoolData.AspectEntry> aspects) {
+        int spacing = getAspectSpacing();
+        int height = 0;
+
+        // Mythic
+        int mythicCount = (int) aspects.stream()
+            .filter(a -> a.rarity.equalsIgnoreCase("Mythic"))
+            .filter(a -> !hideMaxInLootPools || a.tierInfo == null || !a.tierInfo.contains("[MAX]"))
+            .filter(a -> !showOnlyFavoritesInLootPools || FavoriteAspectsData.INSTANCE.isFavorite(a.name))
+            .count();
+        if (mythicCount > 0) {
+            height += mythicCount * spacing + 6; // Aspects + spacing between groups
+        }
+
+        // Separator
+        height += 10; // Separator line spacing
+
+        // Fabled
+        int fabledCount = (int) aspects.stream()
+            .filter(a -> a.rarity.equalsIgnoreCase("Fabled"))
+            .filter(a -> !hideMaxInLootPools || a.tierInfo == null || !a.tierInfo.contains("[MAX]"))
+            .filter(a -> !showOnlyFavoritesInLootPools || FavoriteAspectsData.INSTANCE.isFavorite(a.name))
+            .count();
+        if (fabledCount > 0) {
+            height += fabledCount * spacing + 6;
+        }
+
+        // Separator
+        height += 10;
+
+        // Legendary
+        int legendaryCount = (int) aspects.stream()
+            .filter(a -> a.rarity.equalsIgnoreCase("Legendary"))
+            .filter(a -> !hideMaxInLootPools || a.tierInfo == null || !a.tierInfo.contains("[MAX]"))
+            .filter(a -> !showOnlyFavoritesInLootPools || FavoriteAspectsData.INSTANCE.isFavorite(a.name))
+            .count();
+        if (legendaryCount > 0) {
+            height += legendaryCount * spacing + 6;
+        }
+
+        return height;
+    }
+
+    /**
+     * Draw a scroll bar indicator
+     */
+    private void drawScrollBar(DrawContext context, int x, int y, int barWidth, int barHeight, int scrollOffset, int totalContentHeight) {
+        // Background track (in logical coords)
+        drawRect(x, y, barWidth, barHeight, 0x40FFFFFF);
+
+        // Calculate thumb size and position
+        float visibleRatio = (float) barHeight / totalContentHeight;
+        int thumbHeight = Math.max(60, (int)(barHeight * visibleRatio)); // Min 60 in logical units
+        int maxScroll = totalContentHeight - barHeight;
+        float scrollRatio = maxScroll > 0 ? (float) scrollOffset / maxScroll : 0;
+        int thumbY = y + (int)((barHeight - thumbHeight) * scrollRatio);
+
+        // Thumb
+        drawRect(x, thumbY, barWidth, thumbHeight, 0xFFAAAAAA);
+    }
+
+    private int drawAspectsByRarity(DrawContext context, int x, int y, List<LootPoolData.AspectEntry> aspects, String rarity, String prefix, String color, int colWidth) {
+        List<LootPoolData.AspectEntry> filtered = aspects.stream()
+            .filter(a -> a.rarity.equalsIgnoreCase(rarity))
+            .filter(a -> !hideMaxInLootPools || a.tierInfo == null || !a.tierInfo.contains("[MAX]"))
+            .filter(a -> !showOnlyFavoritesInLootPools || FavoriteAspectsData.INSTANCE.isFavorite(a.name))
+            .toList();
+
+        if (filtered.isEmpty()) return y;
+
+        // Truncation - 32 chars max
+        int maxChars = 32;
+
+        for (LootPoolData.AspectEntry aspect : filtered) {
+            // Check if aspect is maxed
+            boolean isMaxed = aspect.tierInfo != null && aspect.tierInfo.contains("[MAX]");
+
+            // Truncate by character count - always truncate if longer than maxChars
+            String displayName = aspect.name;
+            if (displayName.length() > maxChars) {
+                displayName = displayName.substring(0, maxChars - 3) + "...";
+            }
+            String displayText = prefix.isEmpty() ? displayName : prefix + " " + displayName;
+
+            // Check if favorited
+            boolean isFavorite = FavoriteAspectsData.INSTANCE.isFavorite(aspect.name);
+
+            // Check if this specific aspect instance is being hovered (same name AND same column)
+            boolean isHovered = hoveredAspect != null && hoveredAspect.name.equals(aspect.name) && hoveredAspectColumnX == x;
+
+            // Show star: filled if favorite, empty if hovered but not favorite, nothing otherwise
+            String favoriteStar;
+            if (isFavorite) {
+                favoriteStar = " §e⭐";
+            } else if (isHovered) {
+                favoriteStar = " §7☆";
+            } else {
+                favoriteStar = "";
+            }
+
+            // Draw text at y position - rainbow for maxed aspects
+            if (isMaxed && ui != null) {
+                ui.drawText(displayText + favoriteStar, x + 55, y, CommonColors.RAINBOW, 3f);
+            } else {
+                drawLeftText(context, color + displayText + favoriteStar, x + 55, y);
+            }
+
+            // Draw flame icon
+            ApiAspect apiAspect = findApiAspectByName(aspect.name);
+            ItemStack flameItem = createAspectFlameIcon(apiAspect, isMaxed);
+            if (!flameItem.isEmpty() && ui != null) {
+                int screenX = (int)ui.sx(x + 20);
+                int screenY = (int)ui.sy(y); // Move flame up
+                float flameScale = 0.6f;
+                context.getMatrices().pushMatrix();
+                context.getMatrices().scale(flameScale, flameScale);
+                context.drawItem(flameItem, (int)(screenX / flameScale), (int)(screenY / flameScale));
+                context.getMatrices().popMatrix();
+            }
+
+            y += getAspectSpacing();
+        }
+
+        y += 15; // Spacing between rarity groups
+        return y;
+    }
+
+    // Separate method to check hover (called with logical mouse coords)
+    private void checkAspectHover(int mouseX, int mouseY, int x, int y, List<LootPoolData.AspectEntry> aspects, String rarity, String prefix, int colWidth) {
+        List<LootPoolData.AspectEntry> filtered = aspects.stream()
+            .filter(a -> a.rarity.equalsIgnoreCase(rarity))
+            .filter(a -> !hideMaxInLootPools || a.tierInfo == null || !a.tierInfo.contains("[MAX]"))
+            .filter(a -> !showOnlyFavoritesInLootPools || FavoriteAspectsData.INSTANCE.isFavorite(a.name))
+            .toList();
+
+        if (filtered.isEmpty()) return;
+
+        int currentY = y; // Align with text position
+        int lineHeight = getAspectSpacing();
+
+        for (LootPoolData.AspectEntry aspect : filtered) {
+            // Use full column width for hover detection (much easier to hit)
+            if (mouseX >= x + 20 && mouseX <= x + colWidth - 20 &&
+                mouseY >= currentY - 3 && mouseY <= currentY + lineHeight + 3) {
+                hoveredAspect = aspect;
+                hoveredAspectX = mouseX;
+                hoveredAspectY = mouseY;
+                hoveredAspectColumnX = x; // Track which column this aspect is in
+                return;
+            }
+            currentY += lineHeight;
+        }
+    }
+
+    private void renderAspectTooltip(DrawContext context, int mouseX, int mouseY) {
+        if (hoveredAspect == null) return;
+
+        List<Text> tooltipLines = new ArrayList<>();
+
+        // Rarity color
+        String rarityColor = switch(hoveredAspect.rarity.toLowerCase()) {
+            case "mythic" -> "§5";
+            case "fabled" -> "§c";
+            case "legendary" -> "§b";
+            default -> "§f";
+        };
+
+        tooltipLines.add(Text.literal(rarityColor + hoveredAspect.name));
+
+        if (hoveredAspect.tierInfo != null && !hoveredAspect.tierInfo.isEmpty()) {
+            // Strip Wynncraft symbols and colorize tier info
+            String cleanTierInfo = stripWynncraftSymbols(hoveredAspect.tierInfo);
+            String coloredTierInfo = colorizeTierInfo(cleanTierInfo, rarityColor);
+            tooltipLines.add(Text.literal(coloredTierInfo));
+        }
+
+        // Try to get description from API if saved description is empty
+        String description = hoveredAspect.description;
+        if (description == null || description.isEmpty()) {
+            // Fetch from API
+            try {
+                List<ApiAspect> allAspects = WynncraftApiHandler.fetchAllAspects();
+                if (allAspects != null && !allAspects.isEmpty()) {
+                    for (ApiAspect apiAspect : allAspects) {
+                        if (apiAspect != null && apiAspect.getName().equals(hoveredAspect.name)) {
+                            // Get description for current tier (not first tier)
+                            description = getDescriptionForCurrentTierFromTierInfo(apiAspect, hoveredAspect.tierInfo);
+                            break;
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                // Silently fail - just won't show description
+            }
+        }
+
+        if (description != null && !description.isEmpty()) {
+            tooltipLines.add(Text.literal(""));
+            // Strip symbols and handle multi-line descriptions
+            String cleanDesc = stripWynncraftSymbols(description);
+
+            // Split by newlines first (for multiple features)
+            String[] descriptionLines = cleanDesc.split("\n");
+            for (String descLine : descriptionLines) {
+                if (descLine.trim().isEmpty()) continue;
+
+                // Word wrap each line individually
+                List<String> wrappedLines = wrapText(descLine.trim(), 200);
+                for (String line : wrappedLines) {
+                    tooltipLines.add(Text.literal("§7" + line));
+                }
+            }
+        }
+
+        context.drawTooltip(textRenderer, tooltipLines, mouseX, mouseY);
+    }
+
+    private String getDescriptionFromApiAspect(ApiAspect aspect) {
+        if (aspect.getTiers() == null || aspect.getTiers().isEmpty()) return "";
+
+        // Get the first tier (lowest tier) description
+        ApiAspect.Tier firstTier = null;
+        int lowestThreshold = Integer.MAX_VALUE;
+
+        for (Map.Entry<String, ApiAspect.Tier> entry : aspect.getTiers().entrySet()) {
+            int threshold = entry.getValue().getThreshold();
+            if (threshold < lowestThreshold) {
+                lowestThreshold = threshold;
+                firstTier = entry.getValue();
+            }
+        }
+
+        if (firstTier != null && firstTier.getDescription() != null && !firstTier.getDescription().isEmpty()) {
+            return String.join("\n", firstTier.getDescription());
+        }
+
+        return "";
+    }
+
+    private String getDescriptionForCurrentTierFromTierInfo(ApiAspect aspect, String tierInfo) {
+        if (aspect.getTiers() == null || aspect.getTiers().isEmpty()) return "";
+
+        // Collect ALL descriptions from all tiers to show complete feature list
+        StringBuilder allDescriptions = new StringBuilder();
+
+        // Try to get the highest tier's description (which usually has all features)
+        int maxTierNum = 0;
+        ApiAspect.Tier maxTier = null;
+
+        for (Map.Entry<String, ApiAspect.Tier> entry : aspect.getTiers().entrySet()) {
+            String tierKey = entry.getKey();
+            // Extract tier number from "tier1", "tier2", etc.
+            try {
+                int tierNum = Integer.parseInt(tierKey.replace("tier", "").trim());
+                if (tierNum > maxTierNum) {
+                    maxTierNum = tierNum;
+                    maxTier = entry.getValue();
+                }
+            } catch (NumberFormatException e) {
+                // Try roman numerals
+                String tierStr = tierKey.replace("tier", "").trim();
+                int tierNum = romanToInt(tierStr);
+                if (tierNum > maxTierNum) {
+                    maxTierNum = tierNum;
+                    maxTier = entry.getValue();
+                }
+            }
+        }
+
+        // Use highest tier description (usually most complete)
+        if (maxTier != null && maxTier.getDescription() != null && !maxTier.getDescription().isEmpty()) {
+            return String.join("\n", maxTier.getDescription());
+        }
+
+        // Fallback to first tier
+        return getDescriptionFromApiAspect(aspect);
+    }
+
+    /**
+     * Strip Wynncraft custom font characters, formatting codes, and HTML tags
+     */
+    private String stripWynncraftSymbols(String text) {
+        if (text == null) return "";
+
+        // Remove Unicode private use area characters (U+E000 to U+F8FF, U+F0000 to U+FFFFD, U+100000 to U+10FFFD)
+        // Also remove surrogate pairs that form these characters
+        return text.replaceAll("[\\uE000-\\uF8FF]", "")
+                   .replaceAll("[\\uDB40-\\uDBFF][\\uDC00-\\uDFFF]", "")
+                   .replaceAll("[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]", "")
+                   .replaceAll("\\{[^}]*\\}", "") // Remove {Music}, {Bloodpool}, etc.
+                   .replaceAll("§.", "") // Remove Minecraft formatting codes (§a, §7, etc.)
+                   .replaceAll("<[^>]*>", "") // Remove HTML tags like <span class="...">, </span>, etc.
+                   .replaceAll("&[a-zA-Z]+;", "") // Remove HTML entities like &nbsp;, &amp;, etc.
+                   .trim();
+    }
+
+    /**
+     * Colorize tier info: "Tier I >>>>>>>>>> TIER II [8/10]"
+     * - "Tier I" = gray (lower tier)
+     * - ">>>>>>>>" = partially green based on progress (8/10 = 80% green, 20% gray)
+     * - "TIER II" = aspect color (target tier)
+     * - "[8/10]" = gray
+     * - "[MAX]" = aspect color
+     */
+    private String colorizeTierInfo(String tierInfo, String aspectColor) {
+        if (tierInfo == null || tierInfo.isEmpty()) return "";
+
+        // Handle [MAX] case - use aspect color
+        if (tierInfo.contains("[MAX]")) {
+            return aspectColor + "[MAX]";
+        }
+
+        // Pattern: "Tier I >>>>>>>>>> TIER II [8/10]"
+        // We need to parse the progress [X/Y] and partially color the arrows
+
+        // Extract progress numbers
+        int current = 0;
+        int total = 1;
+        java.util.regex.Pattern progressPattern = java.util.regex.Pattern.compile("\\[(\\d+)/(\\d+)\\]");
+        java.util.regex.Matcher progressMatcher = progressPattern.matcher(tierInfo);
+        if (progressMatcher.find()) {
+            current = Integer.parseInt(progressMatcher.group(1));
+            total = Integer.parseInt(progressMatcher.group(2));
+        }
+
+        // Calculate progress percentage
+        double progressPercent = total > 0 ? (double) current / total : 0;
+
+        // Find and color the arrow sequence
+        java.util.regex.Pattern arrowPattern = java.util.regex.Pattern.compile("([>≻→»]+)");
+        java.util.regex.Matcher arrowMatcher = arrowPattern.matcher(tierInfo);
+
+        StringBuilder result = new StringBuilder();
+        int lastEnd = 0;
+
+        while (arrowMatcher.find()) {
+            // Add text before arrows
+            String before = tierInfo.substring(lastEnd, arrowMatcher.start());
+            result.append(colorizeNonArrowPart(before, aspectColor));
+
+            // Color arrows based on progress
+            String arrows = arrowMatcher.group(1);
+            int arrowCount = arrows.length();
+            int greenCount = (int) Math.ceil(arrowCount * progressPercent);
+
+            // Green portion
+            for (int i = 0; i < greenCount; i++) {
+                result.append("§a").append(arrows.charAt(i));
+            }
+            // Gray portion
+            for (int i = greenCount; i < arrowCount; i++) {
+                result.append("§7").append(arrows.charAt(i));
+            }
+
+            lastEnd = arrowMatcher.end();
+        }
+
+        // Add remaining text after arrows
+        if (lastEnd < tierInfo.length()) {
+            result.append(colorizeNonArrowPart(tierInfo.substring(lastEnd), aspectColor));
+        }
+
+        return result.toString();
+    }
+
+    /**
+     * Helper to colorize the non-arrow parts of tier info
+     */
+    private String colorizeNonArrowPart(String text, String aspectColor) {
+        if (text == null || text.isEmpty()) return "";
+
+        String result = text;
+
+        // Color lower tier (lowercase "tier") = gray
+        result = result.replaceAll("(?i)(tier\\s+[IVX]+)(?!.*TIER)", "§7$1");
+
+        // Color target tier (uppercase "TIER") = aspect color
+        result = result.replaceAll("(TIER\\s+[IVX]+)", aspectColor + "$1");
+
+        // Color progress numbers [X/Y] = gray
+        result = result.replaceAll("(\\[\\d+/\\d+\\])", "§7$1");
+
+        return result;
+    }
+
+    private void renderGambitsPage(DrawContext context, int mouseX, int mouseY) {
+        int logicalW = getLogicalWidth();
+        int logicalH = getLogicalHeight();
+        int centerX = logicalW / 2;
+
+        // Title
+        drawCenteredText(context, "§6§lTODAY'S GAMBITS", centerX, 60);
+
+        // Calculate time until next refresh (19:00 Berlin time)
+        String countdown = getGambitCountdown();
+        drawCenteredText(context, "§7" + countdown, centerX, 110);
+
+        // Fetch crowdsourced gambits from API on first load
+        if (!fetchedCrowdsourcedGambits) {
+            fetchedCrowdsourcedGambits = true;
+            WynncraftApiHandler.fetchCrowdsourcedGambits().thenAccept(result -> {
+                crowdsourcedGambits = result;
+                if (result != null && !result.isEmpty()) {
+                    System.out.println("[WynnExtras] Fetched " + result.size() + " crowdsourced gambits from API");
+                    // Save to local data for offline access
+                    julianh06.wynnextras.features.aspects.GambitData.INSTANCE.saveGambits(result);
+                } else {
+                    System.out.println("[WynnExtras] No crowdsourced gambits available from API");
+                }
+            });
+        }
+
+        int startY = 180;
+
+        int panelWidth = Math.min(800, (logicalW - 200) / 2);
+        int panelHeight = 180;
+        int spacingH = 50;
+        int spacingV = 40;
+
+        // Use crowdsourced data if available, otherwise fall back to local data
+        List<julianh06.wynnextras.features.aspects.GambitData.GambitEntry> gambitsToShow;
+        String dataSource;
+
+        if (crowdsourcedGambits != null && !crowdsourcedGambits.isEmpty()) {
+            gambitsToShow = crowdsourcedGambits;
+            dataSource = "§a(Crowdsourced)";
+        } else {
+            // Fall back to local data
+            GambitData data = GambitData.INSTANCE;
+            if (data.hasToday() && !data.gambits.isEmpty()) {
+                gambitsToShow = data.gambits;
+                dataSource = "§e(Local - Upload to share!)";
+            } else {
+                gambitsToShow = null;
+                dataSource = "";
+            }
+        }
+
+        if (gambitsToShow == null || gambitsToShow.isEmpty()) {
+            // No gambit data at all
+            if (crowdsourcedGambits == null) {
+                drawCenteredText(context, "§7Loading crowdsourced data...", centerX, startY + 150);
+            } else {
+                drawCenteredText(context, "§7No gambit data available yet", centerX, startY + 150);
+                drawCenteredText(context, "§e§nClick to open Party Finder /pf to scan", centerX, startY + 200);
+            }
+        } else {
+            // Show data source
+            drawCenteredText(context, dataSource, centerX, 140);
+
+            // Draw gambits in 2 columns (2 per row) - in logical units
+            int totalWidth = (panelWidth * 2) + spacingH;
+            int startX = (logicalW - totalWidth) / 2;
+
+            // Draw up to 4 gambits in 2 columns
+            for (int i = 0; i < Math.min(gambitsToShow.size(), 4); i++) {
+                julianh06.wynnextras.features.aspects.GambitData.GambitEntry gambit = gambitsToShow.get(i);
+
+                int col = i % 2; // 0 = left, 1 = right
+                int row = i / 2; // 0 = top row, 1 = bottom row
+
+                int x = startX + (col * (panelWidth + spacingH));
+                int y = startY + (row * (panelHeight + spacingV));
+
+                drawGambitPanel(context, x, y, panelWidth, panelHeight, gambit);
+            }
+        }
+
+        // Misc Stats below gambits - always show
+        int statsStartY = startY + (2 * (panelHeight + spacingV)) + 80;
+        drawMiscStats(context, centerX, statsStartY);
+    }
+
+    private String getRefreshTimeInfo() {
+        try {
+            // 19:00 Berlin time = what time in user's timezone?
+            ZoneId berlinZone = ZoneId.of("Europe/Berlin");
+            ZoneId localZone = ZoneId.systemDefault();
+
+            // Create a time for 19:00 Berlin time today
+            LocalDate today = LocalDate.now(berlinZone);
+            LocalTime berlinRefreshTime = LocalTime.of(19, 0);
+            ZonedDateTime berlinRefresh = ZonedDateTime.of(today, berlinRefreshTime, berlinZone);
+
+            // Convert to user's local time
+            ZonedDateTime localRefresh = berlinRefresh.withZoneSameInstant(localZone);
+
+            // Format the time
+            DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
+            String localTime = localRefresh.format(timeFormatter);
+
+            // Get timezone abbreviation
+            String tzAbbrev = localRefresh.getZone().getDisplayName(java.time.format.TextStyle.SHORT, java.util.Locale.ENGLISH);
+
+            return "Gambits refresh daily at " + localTime + " " + tzAbbrev;
+        } catch (Exception e) {
+            return "Gambits refresh daily at 19:00 CET";
+        }
+    }
+
+    private void drawGambitPanel(DrawContext context, int x, int y, int panelWidth, int panelHeight, GambitData.GambitEntry gambit) {
+        // Background (using logical coords)
+        drawRect(x, y, panelWidth, panelHeight, 0xAA000000);
+
+        // Border
+        drawRect(x, y, panelWidth, 5, 0xFF4e392d); // Top
+        drawRect(x, y + panelHeight - 5, panelWidth, 5, 0xFF4e392d); // Bottom
+        drawRect(x, y, 5, panelHeight, 0xFF4e392d); // Left
+        drawRect(x + panelWidth - 5, y, 5, panelHeight, 0xFF4e392d); // Right
+
+        // Gambit name (truncate by chars) - account for padding
+        String truncatedName = gambit.name;
+        int maxNameChars = (panelWidth - 60) / 12; // subtract padding
+        if (truncatedName.length() > maxNameChars) {
+            truncatedName = truncatedName.substring(0, Math.max(3, maxNameChars - 3)) + "...";
+        }
+        drawLeftText(context, "§6§l" + truncatedName, x + 30, y + 25);
+
+        // Description (word wrapped) - very tight chars per line to prevent overflow
+        String desc = gambit.description;
+        int charsPerLine = (panelWidth - 80) / 20; // very conservative - account for padding and text scale
+        List<String> lines = wrapTextByChars(desc, charsPerLine);
+
+        int textY = y + 70;
+        int lineSpacing = 30; // slightly tighter
+        int maxLines = (panelHeight - 90) / lineSpacing; // calculate based on available space
+        for (int i = 0; i < Math.min(lines.size(), maxLines); i++) {
+            if (textY < y + panelHeight - 25) {
+                drawLeftText(context, "§7" + lines.get(i), x + 30, textY);
+                textY += lineSpacing;
+            }
+        }
+    }
+
+    private List<String> wrapTextByChars(String text, int maxChars) {
+        List<String> lines = new ArrayList<>();
+        if (text == null || text.isEmpty()) return lines;
+
+        String[] words = text.split(" ");
+        StringBuilder currentLine = new StringBuilder();
+
+        for (String word : words) {
+            // If word alone is too long, truncate it
+            if (word.length() > maxChars) {
+                // Flush current line first
+                if (currentLine.length() > 0) {
+                    lines.add(currentLine.toString());
+                    currentLine = new StringBuilder();
+                }
+                lines.add(word.substring(0, Math.max(1, maxChars - 3)) + "...");
+                continue;
+            }
+
+            // Check if word fits on current line
+            int neededSpace = currentLine.length() > 0 ? word.length() + 1 : word.length();
+            if (currentLine.length() + neededSpace <= maxChars) {
+                if (currentLine.length() > 0) currentLine.append(" ");
+                currentLine.append(word);
+            } else {
+                // Word doesn't fit, start new line
+                if (currentLine.length() > 0) {
+                    lines.add(currentLine.toString());
+                }
+                currentLine = new StringBuilder(word);
+            }
+        }
+        // Add final line, truncate if needed
+        if (currentLine.length() > 0) {
+            String finalLine = currentLine.toString();
+            if (finalLine.length() > maxChars) {
+                finalLine = finalLine.substring(0, Math.max(1, maxChars - 3)) + "...";
+            }
+            lines.add(finalLine);
+        }
+        return lines;
+    }
+
+    private void drawMiscStats(DrawContext context, int centerX, int startY) {
+        drawCenteredText(context, "§6§lMISC STATS", centerX, startY);
+
+        // Calculate raid stats from RaidListData
+        int totalRuns = RaidListData.INSTANCE.getRaids().size();
+        int completedRuns = (int) RaidListData.INSTANCE.getRaids().stream().filter(r -> r.completed).count();
+        int failedRuns = totalRuns - completedRuns;
+
+        // Calculate per-raid stats
+        long notgRuns = RaidListData.INSTANCE.getRaids().stream()
+            .filter(r -> r.raidInfo.toString().contains("Orphion"))
+            .count();
+        long nolRuns = RaidListData.INSTANCE.getRaids().stream()
+            .filter(r -> r.raidInfo.toString().contains("Lair"))
+            .count();
+        long tccRuns = RaidListData.INSTANCE.getRaids().stream()
+            .filter(r -> r.raidInfo.toString().contains("Canyon"))
+            .count();
+        long tnaRuns = RaidListData.INSTANCE.getRaids().stream()
+            .filter(r -> r.raidInfo.toString().contains("Nameless"))
+            .count();
+
+        // Calculate aspect pull stats
+        int totalAspectsPulled = 0;
+        int mythicAspectsPulled = 0;
+
+        if (myAspectsData != null && myAspectsData.getAspects() != null) {
+            List<ApiAspect> allAspects = WynncraftApiHandler.fetchAllAspects();
+            for (Aspect playerAspect : myAspectsData.getAspects()) {
+                totalAspectsPulled += playerAspect.getAmount();
+
+                // Check if this aspect is mythic
+                for (ApiAspect apiAspect : allAspects) {
+                    if (apiAspect.getName().equals(playerAspect.getName())) {
+                        if (apiAspect.getRarity().equalsIgnoreCase("mythic")) {
+                            mythicAspectsPulled += playerAspect.getAmount();
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Use larger spacing for text at scale 3f (approx 24 logical pixels per line)
+        int lineHeight = 30;
+        int sectionGap = 40;
+        int yOffset = startY + sectionGap;
+
+        // Display stats in a clean layout
+        drawCenteredText(context, "§e§lTotal Runs: §f" + totalRuns, centerX, yOffset);
+        yOffset += lineHeight;
+
+        drawCenteredText(context, "§a§lCompleted: §f" + completedRuns + " §8| §c§lFailed: §f" + failedRuns, centerX, yOffset);
+        yOffset += sectionGap;
+
+        // Aspect pull stats
+        drawCenteredText(context, "§6§lTotal Aspects Pulled: §f" + totalAspectsPulled, centerX, yOffset);
+        yOffset += lineHeight;
+
+        drawCenteredText(context, "§5§lMythic Aspects Pulled: §f" + mythicAspectsPulled, centerX, yOffset);
+        yOffset += sectionGap;
+
+        // Per-raid breakdown
+        drawCenteredText(context, "§7Per-Raid Runs:", centerX, yOffset);
+        yOffset += lineHeight;
+
+        drawCenteredText(context, "§5NOTG: §f" + notgRuns + " §8| §bNOL: §f" + nolRuns, centerX, yOffset);
+        yOffset += lineHeight;
+
+        drawCenteredText(context, "§cTCC: §f" + tccRuns + " §8| §eTNA: §f" + tnaRuns, centerX, yOffset);
+    }
+
+    private String getGambitCountdown() {
+        try {
+            ZoneId berlinZone = ZoneId.of("Europe/Berlin");
+            ZonedDateTime now = ZonedDateTime.now(berlinZone);
+
+            // Next refresh is at 19:00 today or tomorrow
+            ZonedDateTime nextRefresh = now.withHour(19).withMinute(0).withSecond(0).withNano(0);
+            if (now.isAfter(nextRefresh)) {
+                nextRefresh = nextRefresh.plusDays(1);
+            }
+
+            Duration duration = Duration.between(now, nextRefresh);
+            long hours = duration.toHours();
+            long minutes = duration.toMinutes() % 60;
+
+            return String.format("Refreshing in %dh %02dm", hours, minutes);
+        } catch (Exception e) {
+            return "Refreshes daily at 19:00 CET";
+        }
+    }
+
+    private double calculateRaidScore(List<LootPoolData.AspectEntry> aspects) {
+        double score = 0.0;
+
+        System.out.println("[WynnExtras DEBUG] calculateRaidScore called with " + aspects.size() + " aspects");
+
+        for (LootPoolData.AspectEntry aspect : aspects) {
+            String tierInfo = aspect.tierInfo;
+            System.out.println("[WynnExtras DEBUG] Aspect: " + aspect.name + " | tierInfo: " + tierInfo);
+
+            if (tierInfo == null || tierInfo.isEmpty() || tierInfo.contains("[MAX]")) {
+                System.out.println("[WynnExtras DEBUG] Skipping (maxed or no data)");
+                continue; // Already maxed or no data, no score contribution
+            }
+
+            // Parse tierInfo: "Tier I >>>>>> Tier II [10/14]"
+            int remaining = 0;
+            String currentTierStr = "";
+            String targetTierStr = "";
+
+            // Extract remaining count [X/Y]
+            java.util.regex.Pattern progressPattern = java.util.regex.Pattern.compile("\\[(\\d+)/(\\d+)\\]");
+            java.util.regex.Matcher progressMatcher = progressPattern.matcher(tierInfo);
+            if (!progressMatcher.find()) {
+                System.out.println("[WynnExtras DEBUG] Failed to parse progress pattern");
+                continue; // Can't parse progress, skip this aspect
+            }
+
+            int current = Integer.parseInt(progressMatcher.group(1));
+            int max = Integer.parseInt(progressMatcher.group(2));
+            remaining = max - current;
+            System.out.println("[WynnExtras DEBUG] Progress: " + current + "/" + max + " | Remaining: " + remaining);
+
+            // Extract tiers (match I, II, III, IV properly)
+            java.util.regex.Pattern tierPattern = java.util.regex.Pattern.compile("Tier\\s+(IV|III|II|I)");
+            java.util.regex.Matcher tierMatcher = tierPattern.matcher(tierInfo);
+            if (tierMatcher.find()) {
+                currentTierStr = tierMatcher.group(1); // First match = current tier
+                if (tierMatcher.find()) {
+                    targetTierStr = tierMatcher.group(1); // Second match = target tier
+                } else {
+                    // No target tier found - working to max out current tier
+                    targetTierStr = currentTierStr;
+                }
+            } else {
+                System.out.println("[WynnExtras DEBUG] Failed to parse tier pattern");
+                continue; // Can't parse tiers, skip this aspect
+            }
+
+            System.out.println("[WynnExtras DEBUG] Current tier: " + currentTierStr + " | Target tier: " + targetTierStr);
+
+            int currentTier = romanToInt(currentTierStr);
+            int targetTier = romanToInt(targetTierStr);
+
+            if (currentTier == 0 || targetTier == 0) {
+                System.out.println("[WynnExtras DEBUG] Invalid tier numbers");
+                continue; // Invalid tier, skip
+            }
+
+            // Apply tier-based weights
+            double weight = getTierWeight(aspect.rarity, currentTier, targetTier);
+            double contribution = remaining * weight;
+            System.out.println("[WynnExtras DEBUG] Weight: " + weight + " | Contribution: " + contribution);
+
+            // Favorite aspects count 3x more
+            if (FavoriteAspectsData.INSTANCE.isFavorite(aspect.name)) {
+                contribution *= 3.0;
+                System.out.println("[WynnExtras DEBUG] Favorite! Contribution after 3x: " + contribution);
+            }
+
+            score += contribution;
+        }
+
+        System.out.println("[WynnExtras DEBUG] Final score: " + score);
+        return score;
+    }
+
+    /**
+     * Calculate tier weight based on rarity and tier progression.
+     */
+    private double getTierWeight(String rarity, int currentTier, int targetTier) {
+        String key = rarity.toLowerCase() + "_" + currentTier + "_" + targetTier;
+
+        return switch (key) {
+            // Known weights from data
+            case "mythic_2_3" -> 13.55;
+            case "fabled_1_2" -> 10.4;
+            case "fabled_2_3" -> 0.65;
+            case "legendary_3_4" -> 0.905;
+
+            // Tier progressions (estimated based on rarity pattern)
+            case "mythic_1_2" -> 20.0;
+            case "mythic_3_4" -> 10.0;
+            case "fabled_3_4" -> 0.5;
+            case "legendary_1_2" -> 15.0;
+            case "legendary_2_3" -> 1.5;
+
+            // Same-tier progression (finishing current tier)
+            case "mythic_1_1" -> 20.0;
+            case "mythic_2_2" -> 13.55;
+            case "mythic_3_3" -> 10.0;
+            case "mythic_4_4" -> 5.0;
+            case "fabled_1_1" -> 10.4;
+            case "fabled_2_2" -> 5.0;
+            case "fabled_3_3" -> 0.65;
+            case "fabled_4_4" -> 0.5;
+            case "legendary_1_1" -> 15.0;
+            case "legendary_2_2" -> 5.0;
+            case "legendary_3_3" -> 1.5;
+            case "legendary_4_4" -> 0.905;
+
+            // Rare weights
+            case "rare_1_1", "rare_2_2", "rare_3_3", "rare_4_4" -> 1.0;
+            case "rare_1_2", "rare_2_3", "rare_3_4" -> 1.0;
+
+            default -> 1.0; // Default weight
+        };
+    }
+
+    private int romanToInt(String roman) {
+        return switch (roman.toUpperCase()) {
+            case "I" -> 1;
+            case "II" -> 2;
+            case "III" -> 3;
+            case "IV" -> 4;
+            default -> 0;
+        };
+    }
+
+    private void renderMyAspectsPage(DrawContext context, int mouseX, int mouseY) {
+        // Reset hovered aspect
+        hoveredMyAspect = null;
+        hoveredMyAspectProgress = null;
+
+        int logicalW = getLogicalWidth();
+        int logicalH = getLogicalHeight();
+        int centerX = logicalW / 2;
+
+        // Convert mouse to logical coords
+        int logicalMouseX = (int)(mouseX * scaleFactor);
+        int logicalMouseY = (int)(mouseY * scaleFactor);
+
+        // First, check if aspect database is loaded - this must happen first
+        List<ApiAspect> allAspects = new ArrayList<>(WynncraftApiHandler.fetchAllAspects());
+        if (allAspects.isEmpty()) {
+            drawCenteredText(context, "§eLoading aspect database...", centerX, logicalH / 2);
+            return;
+        }
+
+        // Determine which data source to use (own aspects or searched player's aspects)
+        User activeAspectsData;
+        WynncraftApiHandler.FetchStatus activeStatus;
+
+        if (!searchedPlayer.isEmpty()) {
+            // Viewing another player's aspects
+            activeAspectsData = searchedPlayerData;
+            activeStatus = searchedPlayerStatus;
+        } else {
+            // Viewing own aspects
+            activeAspectsData = myAspectsData;
+            activeStatus = myAspectsFetchStatus;
+
+            // Fetch aspects if not already fetched
+            if (!fetchedMyAspects && client.player != null) {
+                fetchedMyAspects = true;
+                String playerUuid = client.player.getUuidAsString();
+                final int fetchGen = ++myAspectsFetchGeneration; // Track this request
+
+                WynncraftApiHandler.fetchPlayerAspectData(playerUuid, playerUuid)
+                    .thenAccept(result -> {
+                        // Only update if this is still the current request
+                        if (fetchGen != myAspectsFetchGeneration) return;
+                        if (result == null) return;
+                        if (result.status() != null) {
+                            if (result.status() == WynncraftApiHandler.FetchStatus.OK) {
+                                myAspectsData = result.user();
+                            }
+                            myAspectsFetchStatus = result.status();
+                        }
+                    })
+                    .exceptionally(ex -> {
+                        // Only log if this is still the current request
+                        if (fetchGen == myAspectsFetchGeneration) {
+                            System.err.println("Failed to fetch aspects: " + ex.getMessage());
+                        }
+                        return null;
+                    });
+            }
+        }
+
+        // Show loading or error states
+        if (activeStatus == null) {
+            String loadingText = searchedPlayer.isEmpty() ? "§eLoading your aspects..." : "§eLoading " + searchedPlayer + "'s aspects...";
+            drawCenteredText(context, loadingText, centerX, logicalH / 2);
+            return;
+        }
+
+        switch (activeStatus) {
+            case NOKEYSET:
+                drawCenteredText(context, "§cYou need to set your API key to use this feature", centerX, logicalH / 2 - 30);
+                drawCenteredText(context, "§7Run \"/we apikey\" for more information", centerX, logicalH / 2 + 30);
+                return;
+            case FORBIDDEN:
+                String forbiddenText = searchedPlayer.isEmpty() ? "§cYou need to upload your aspects first" : "§c" + searchedPlayer + " hasn't uploaded their aspects";
+                drawCenteredText(context, forbiddenText, centerX, logicalH / 2 - 30);
+
+                if (searchedPlayer.isEmpty()) {
+                    // Check if hovering for underline effect
+                    boolean hoverForbidden = logicalMouseY >= logicalH / 2 + 10 && logicalMouseY <= logicalH / 2 + 50 &&
+                                            logicalMouseX >= centerX - 400 && logicalMouseX <= centerX + 400;
+                    drawCenteredText(context, hoverForbidden ? "§e§nClick here to scan your aspects" : "§7Click here to scan your aspects", centerX, logicalH / 2 + 30);
+                }
+                return;
+            case UNAUTHORIZED:
+                drawCenteredText(context, "§cYour API key is not connected to your account", centerX, logicalH / 2 - 30);
+                drawCenteredText(context, "§7Run \"/we apikey\" for more information", centerX, logicalH / 2 + 30);
+                return;
+            case NOT_FOUND:
+                drawCenteredText(context, "§cNo aspect data found for your account", centerX, logicalH / 2 - 30);
+                // Check if hovering for underline effect
+                boolean hoverNotFound = logicalMouseY >= logicalH / 2 + 10 && logicalMouseY <= logicalH / 2 + 50 &&
+                                       logicalMouseX >= centerX - 400 && logicalMouseX <= centerX + 400;
+                drawCenteredText(context, hoverNotFound ? "§e§nClick here to scan your aspects" : "§7Click here to scan your aspects", centerX, logicalH / 2 + 30);
+                return;
+            case SERVER_UNREACHABLE:
+                drawCenteredText(context, "§cServer unreachable. Try again later.", centerX, logicalH / 2);
+                return;
+            case SERVER_ERROR:
+                drawCenteredText(context, "§cServer error occurred!", centerX, logicalH / 2);
+                return;
+            case UNKNOWN_ERROR:
+                String failedText = searchedPlayer.isEmpty() ? "§cFailed to load your aspects" : "§cFailed to load " + searchedPlayer + "'s aspects";
+                drawCenteredText(context, failedText, centerX, logicalH / 2);
+                return;
+        }
+
+        if (activeAspectsData == null || activeAspectsData.getAspects() == null) {
+            drawCenteredText(context, "§cNo aspect data found", centerX, logicalH / 2);
+            return;
+        }
+
+        // allAspects was already fetched at the start of this method
+
+        // Show statistics - filtered by current class selection
+        int totalForClass = (int) allAspects.stream()
+            .filter(a -> classFilter.equals("All") || a.getRequiredClass().equalsIgnoreCase(classFilter))
+            .count();
+
+        int unlockedForClass = 0;
+        int maxedForClass = 0;
+
+        for (Aspect playerAspect : activeAspectsData.getAspects()) {
+            ApiAspect apiAspect = allAspects.stream()
+                .filter(a -> a.getName().equals(playerAspect.getName()))
+                .findFirst()
+                .orElse(null);
+
+            if (apiAspect != null) {
+                // Check if matches current class filter
+                if (classFilter.equals("All") || apiAspect.getRequiredClass().equalsIgnoreCase(classFilter)) {
+                    unlockedForClass++;
+
+                    // Check if maxed
+                    int maxAmount = switch (apiAspect.getRarity().toLowerCase()) {
+                        case "mythic" -> 15;
+                        case "fabled" -> 75;
+                        case "legendary" -> 150;
+                        default -> 0;
+                    };
+
+                    if (playerAspect.getAmount() >= maxAmount) {
+                        maxedForClass++;
+                    }
+                }
+            }
+        }
+
+        // Dynamic title based on whose aspects we're viewing
+        String title = searchedPlayer.isEmpty() ? "§6§lYOUR ASPECTS" : "§6§l" + searchedPlayer.toUpperCase() + "'S ASPECTS";
+        drawCenteredText(context, title, centerX, 60);
+
+        // "Back to My Aspects" button if viewing another player (top right as styled button)
+        if (!searchedPlayer.isEmpty()) {
+            int buttonWidth = 260;
+            int buttonHeight = 44;
+            int buttonX = logicalW - buttonWidth - 40;
+            int buttonY = 46;
+            boolean hoverBack = logicalMouseX >= buttonX && logicalMouseX <= buttonX + buttonWidth &&
+                               logicalMouseY >= buttonY && logicalMouseY <= buttonY + buttonHeight;
+
+            // Draw styled button
+            if (hoverBack) {
+                drawRect(buttonX, buttonY, buttonWidth, buttonHeight, 0xAA333333);
+                drawRect(buttonX, buttonY, buttonWidth, 2, 0xFFAAAA00);
+                drawRect(buttonX, buttonY + buttonHeight - 2, buttonWidth, 2, 0xFFAAAA00);
+                drawRect(buttonX, buttonY, 2, buttonHeight, 0xFFAAAA00);
+                drawRect(buttonX + buttonWidth - 2, buttonY, 2, buttonHeight, 0xFFAAAA00);
+            } else {
+                drawRect(buttonX, buttonY, buttonWidth, buttonHeight, 0xAA1a1a1a);
+                drawRect(buttonX, buttonY, buttonWidth, 2, 0xFF4e392d);
+                drawRect(buttonX, buttonY + buttonHeight - 2, buttonWidth, 2, 0xFF4e392d);
+                drawRect(buttonX, buttonY, 2, buttonHeight, 0xFF4e392d);
+                drawRect(buttonX + buttonWidth - 2, buttonY, 2, buttonHeight, 0xFF4e392d);
+            }
+            String backText = hoverBack ? "§e§l< My Aspects" : "§7< My Aspects";
+            drawCenteredText(context, backText, buttonX + buttonWidth / 2, buttonY + buttonHeight / 2);
+        }
+
+        // Draw class selector buttons at top (with Overview button) - moved down to give title space
+        drawClassSelectorButtons(context, logicalMouseX, logicalMouseY, centerX, 100);
+
+        if (showOverview) {
+            // Player search input box (only on overview page) - BELOW the class buttons
+            int searchBoxWidth = 500;
+            int searchBoxHeight = 40;
+            int searchBoxX = centerX - searchBoxWidth / 2;
+            int searchBoxY = 160; // Below class buttons (which end at ~140)
+
+            // Draw search box background using drawRect
+            int boxColor = searchInputFocused ? 0xFFFFAA00 : 0xFFAAAAAA;
+            drawRect(searchBoxX - 2, searchBoxY - 2, searchBoxWidth + 4, searchBoxHeight + 4, boxColor);
+            drawRect(searchBoxX, searchBoxY, searchBoxWidth, searchBoxHeight, 0xFF000000);
+
+            // Draw search text or placeholder
+            if (searchInput.isEmpty() && !searchInputFocused) {
+                drawLeftText(context, "§7Search player...", searchBoxX + 8, searchBoxY + 6);
+            } else {
+                String displayText = searchInput;
+                // Truncate if too long
+                int maxChars = (searchBoxWidth - 20) / 12;
+                if (displayText.length() > maxChars) {
+                    displayText = displayText.substring(displayText.length() - maxChars);
+                }
+                drawLeftText(context, displayText, searchBoxX + 8, searchBoxY + 6);
+
+                // Draw cursor if focused - put at end of text
+                if (searchInputFocused) {
+                    // drawLeftText uses scale 3f, so multiply text width by 3 to get logical units
+                    int textWidthPixels = textRenderer.getWidth(displayText);
+                    int cursorOffset = textWidthPixels * 3; // Scale 3f used in drawLeftText
+                    drawRect(searchBoxX + 8 + cursorOffset, searchBoxY + 4, 2, searchBoxHeight - 8, 0xFFFFFFFF);
+                }
+            }
+
+            // Show overview with progress bars - below search box with more space
+            drawOverview(context, allAspects, activeAspectsData.getAspects(), centerX, 240);
+
+            // Show recent searches dropdown when focused and search is empty (RENDER LAST so it's on top)
+            if (searchInputFocused && searchInput.isEmpty() && !FavoriteAspectsData.INSTANCE.getRecentSearches().isEmpty()) {
+                int dropdownY = searchBoxY + searchBoxHeight + 4;
+                int lineHeight = 28;
+                int dropdownHeight = Math.min(FavoriteAspectsData.INSTANCE.getRecentSearches().size(), MAX_RECENT_SEARCHES) * lineHeight + 8;
+
+                // Draw dropdown background
+                drawRect(searchBoxX - 2, dropdownY - 2, searchBoxWidth + 4, dropdownHeight + 4, 0xFFAAAAAA);
+                drawRect(searchBoxX, dropdownY, searchBoxWidth, dropdownHeight, 0xFF000000);
+
+                // Draw recent searches
+                int yOffset = dropdownY + 4;
+                for (int i = 0; i < Math.min(FavoriteAspectsData.INSTANCE.getRecentSearches().size(), MAX_RECENT_SEARCHES); i++) {
+                    String search = FavoriteAspectsData.INSTANCE.getRecentSearches().get(i);
+                    boolean hoverRecent = logicalMouseX >= searchBoxX && logicalMouseX <= searchBoxX + searchBoxWidth &&
+                                         logicalMouseY >= yOffset && logicalMouseY <= yOffset + lineHeight;
+
+                    if (hoverRecent) {
+                        drawRect(searchBoxX, yOffset - 2, searchBoxWidth, lineHeight, 0x88FFFFFF);
+                    }
+
+                    drawLeftText(context, "§7" + search, searchBoxX + 8, yOffset);
+                    yOffset += lineHeight;
+                }
+            }
+        } else {
+            // Draw max filter buttons below class selector
+            drawMaxFilterButtons(context, mouseX, mouseY, centerX, 180);
+
+            // Show stats for current class with more space
+            String className = classFilter;
+            drawCenteredText(context, "§7" + className + " §8| §7Unlocked: §e" + unlockedForClass + "§7/§e" + totalForClass + " §8| §7Maxed: §a" + maxedForClass, centerX, 250);
+
+            // Draw class-specific progress bars
+            int progressY = drawClassProgressBars(context, allAspects, activeAspectsData.getAspects(), centerX, 290);
+
+            // Show single class in 2-column layout below progress bars
+            drawTwoColumnClassLayout(context, allAspects, activeAspectsData.getAspects(), progressY + 30, mouseX, mouseY);
+        }
+
+        // Render tooltip if hovering
+        if (hoveredMyAspect != null && hoveredMyAspectProgress != null) {
+            renderMyAspectTooltip(context, mouseX, mouseY);
+        }
+
+        // Instructions above navigation - make it clickable (in logical coords)
+        int scanTextY = logicalH - 165;
+        boolean hoverScan = logicalMouseY >= scanTextY - 20 && logicalMouseY <= scanTextY + 40 &&
+                           logicalMouseX >= centerX - 400 && logicalMouseX <= centerX + 400;
+
+        drawCenteredText(context, hoverScan ? "§e§nClick here to scan your aspects" : "§7Click here to scan your aspects", centerX, scanTextY);
+    }
+
+    private int countMaxedAspects(List<ApiAspect> allAspects, List<Aspect> playerAspects) {
+        int count = 0;
+        for (Aspect playerAspect : playerAspects) {
+            for (ApiAspect apiAspect : allAspects) {
+                if (!apiAspect.getName().equals(playerAspect.getName())) continue;
+
+                int maxAmount = switch (apiAspect.getRarity().toLowerCase()) {
+                    case "mythic" -> 15;
+                    case "fabled" -> 75;
+                    case "legendary" -> 150;
+                    default -> 0;
+                };
+
+                if (playerAspect.getAmount() >= maxAmount) {
+                    count++;
+                }
+                break;
+            }
+        }
+        return count;
+    }
+
+    private void drawClassSelectorButtons(DrawContext context, int mouseX, int mouseY, int centerX, int y) {
+        int buttonWidth = 170;
+        int buttonHeight = 40;
+        int spacing = 16;
+
+        String[] buttons = {"Overview", "Warrior", "Shaman", "Mage", "Archer", "Assassin"};
+        int totalWidth = (buttonWidth * buttons.length) + (spacing * (buttons.length - 1));
+        int startX = centerX - totalWidth / 2;
+
+        for (int i = 0; i < buttons.length; i++) {
+            int x = startX + (i * (buttonWidth + spacing));
+            boolean selected = (i == 0 && showOverview) || (i > 0 && !showOverview && classFilter.equals(buttons[i]));
+            boolean hovered = mouseX >= x && mouseX <= x + buttonWidth && mouseY >= y && mouseY <= y + buttonHeight;
+
+            // Button colors
+            String buttonColor;
+            if (i == 0) {
+                buttonColor = "§6"; // Overview is gold
+            } else {
+                buttonColor = switch (buttons[i]) {
+                    case "Warrior" -> "§c";
+                    case "Shaman" -> "§b";
+                    case "Mage" -> "§e";
+                    case "Archer" -> "§d";
+                    case "Assassin" -> "§5";
+                    default -> "§7";
+                };
+            }
+
+            // Draw textured button
+            if (ui != null) {
+                ui.drawButtonFade(x, y, buttonWidth, buttonHeight, 12, hovered || selected);
+            }
+
+            // Draw text - drawCenteredText uses VerticalAlignment.MIDDLE so Y should be center of button
+            String displayText = selected ? buttonColor + "§l" + buttons[i] : (hovered ? buttonColor + buttons[i] : "§7" + buttons[i]);
+            drawCenteredText(context, displayText, x + buttonWidth / 2, y + buttonHeight / 2);
+        }
+    }
+
+    private void drawMaxFilterButtons(DrawContext context, int mouseX, int mouseY, int centerX, int y) {
+        // Convert mouse to logical coords for hover detection
+        int logicalMouseX = (int)(mouseX * scaleFactor);
+        int logicalMouseY = (int)(mouseY * scaleFactor);
+
+        int buttonWidth = 200;
+        int buttonHeight = 44;
+        int spacing = 12;
+
+        String[] filters = {"All", "Max Only", "Not Max", "Favorites"};
+        int totalWidth = (buttonWidth * filters.length) + (spacing * (filters.length - 1));
+        int startX = centerX - totalWidth / 2;
+
+        for (int i = 0; i < filters.length; i++) {
+            int x = startX + (i * (buttonWidth + spacing));
+            boolean selected = maxFilter.equals(filters[i]);
+            boolean hovered = logicalMouseX >= x && logicalMouseX <= x + buttonWidth && logicalMouseY >= y && logicalMouseY <= y + buttonHeight;
+
+            // Draw textured button
+            if (ui != null) {
+                ui.drawButtonFade(x, y, buttonWidth, buttonHeight, 12, hovered || selected);
+            }
+
+            // Draw text - drawCenteredText uses VerticalAlignment.MIDDLE so Y should be center of button
+            String color = selected ? "§6§l" : (hovered ? "§e" : "§7");
+            drawCenteredText(context, color + filters[i], x + buttonWidth / 2, y + buttonHeight / 2);
+        }
+    }
+
+    private void drawImportWynntilsButton(DrawContext context, int logicalMouseX, int logicalMouseY) {
+        int buttonWidth = 400;
+        int buttonHeight = 44;
+        int buttonX = 40;
+        int buttonY = 14;
+
+        boolean hovered = logicalMouseX >= buttonX && logicalMouseX <= buttonX + buttonWidth &&
+                         logicalMouseY >= buttonY && logicalMouseY <= buttonY + buttonHeight;
+
+        // Draw textured button
+        if (ui != null) {
+            ui.drawButtonFade(buttonX, buttonY, buttonWidth, buttonHeight, 12, hovered);
+        }
+
+        // Draw button text
+        String color = hovered ? "§e" : "§7";
+        drawCenteredText(context, color + "Import Wynntils Favorites", buttonX + buttonWidth / 2, buttonY + buttonHeight / 2);
+
+        // Show feedback message if recent import (centered below button)
+        if (importFeedback != null && System.currentTimeMillis() - importFeedbackTime < 5000) {
+            drawCenteredText(context, importFeedback, buttonX + buttonWidth / 2, buttonY + buttonHeight + 16);
+        } else {
+            importFeedback = null;
+        }
+    }
+
+    private void drawTwoColumnClassLayout(DrawContext context, List<ApiAspect> allAspects, List<Aspect> playerAspects, int startY, int mouseX, int mouseY) {
+        int logicalW = getLogicalWidth();
+        int logicalH = getLogicalHeight();
+
+        // Convert mouse to logical coords
+        int logicalMouseX = (int)(mouseX * scaleFactor);
+        int logicalMouseY = (int)(mouseY * scaleFactor);
+
+        // Two columns: Mythic+Fabled on left, Legendary on right - make WIDER with less spacing
+        int columnWidth = Math.min(800, (logicalW - 80) / 2); // Increased max width from 700 to 800
+        int columnSpacing = 20; // Reduced spacing from 30 to 20
+        int leftX = (logicalW / 2) - columnWidth - (columnSpacing / 2);
+        int rightX = (logicalW / 2) + (columnSpacing / 2);
+
+        // Get aspects for current class
+        List<ApiAspect> classAspects = getAspectsForClass(allAspects, playerAspects, classFilter);
+
+        // Left column: Mythic + Fabled - fixed height, not extending to bottom
+        int panelHeight = logicalH - startY - 150; // Changed from -80 to -150 (shorter boxes)
+        drawRect(leftX, startY, columnWidth, panelHeight, 0xAA000000);
+        drawRect(leftX, startY, columnWidth, 4, 0xFF4e392d); // top
+        drawRect(leftX, startY + panelHeight - 4, columnWidth, 4, 0xFF4e392d); // bottom
+        drawRect(leftX, startY, 4, panelHeight, 0xFF4e392d); // left
+        drawRect(leftX + columnWidth - 4, startY, 4, panelHeight, 0xFF4e392d); // right
+
+        // Colored title: Mythic (dark purple) & Fabled (red)
+        drawCenteredText(context, "§5§lMYTHIC §f§l& §c§lFABLED", leftX + columnWidth / 2, startY + 30);
+        drawRect(leftX + 8, startY + 55, columnWidth - 16, 4, 0xFF4e392d); // separator
+
+        int leftY = startY + 80;
+        leftY = drawAspectsByRarityForClass(context, leftX, leftY, classAspects, playerAspects, "mythic", "§5", columnWidth, logicalMouseX, logicalMouseY);
+        leftY = drawAspectsByRarityForClass(context, leftX, leftY, classAspects, playerAspects, "fabled", "§c", columnWidth, logicalMouseX, logicalMouseY);
+
+        // Right column: Legendary (light blue)
+        drawRect(rightX, startY, columnWidth, panelHeight, 0xAA000000);
+        drawRect(rightX, startY, columnWidth, 4, 0xFF4e392d); // top
+        drawRect(rightX, startY + panelHeight - 4, columnWidth, 4, 0xFF4e392d); // bottom
+        drawRect(rightX, startY, 4, panelHeight, 0xFF4e392d); // left
+        drawRect(rightX + columnWidth - 4, startY, 4, panelHeight, 0xFF4e392d); // right
+
+        drawCenteredText(context, "§b§lLEGENDARY", rightX + columnWidth / 2, startY + 30);
+        drawRect(rightX + 8, startY + 55, columnWidth - 16, 4, 0xFF4e392d); // separator
+
+        int rightY = startY + 80;
+        drawAspectsByRarityForClass(context, rightX, rightY, classAspects, playerAspects, "legendary", "§b", columnWidth, logicalMouseX, logicalMouseY);
+    }
+
+    private void drawOverview(DrawContext context, List<ApiAspect> allAspects, List<Aspect> playerAspects, int centerX, int startY) {
+        int logicalW = getLogicalWidth();
+
+        drawCenteredText(context, "§6§lOVERVIEW", centerX, startY);
+
+        // Mode toggle button (Max vs Unlocked) - right side
+        int toggleWidth = 160;
+        int toggleHeight = 36;
+        int toggleX = centerX + 300;
+        int toggleY = startY - 10;
+
+        String modeText = progressBarShowMax ? "§a§lMax" : "§e§lUnlocked";
+        drawRect(toggleX, toggleY, toggleWidth, toggleHeight, 0xAA1a1a1a);
+        drawRect(toggleX, toggleY, toggleWidth, 2, 0xFF4e392d);
+        drawRect(toggleX, toggleY + toggleHeight - 2, toggleWidth, 2, 0xFF4e392d);
+        drawRect(toggleX, toggleY, 2, toggleHeight, 0xFF4e392d);
+        drawRect(toggleX + toggleWidth - 2, toggleY, 2, toggleHeight, 0xFF4e392d);
+        drawCenteredText(context, modeText, toggleX + toggleWidth / 2, toggleY + toggleHeight / 2);
+
+        int barStartY = startY + 50;
+        int barWidth = Math.min(800, logicalW - 600); // use logical width, give more space for labels
+        int barX = centerX - barWidth / 2 + 50; // shift bar right a bit for label space
+
+        // Calculate totals based on mode
+        int totalAspects = allAspects.size();
+        int totalCount = progressBarShowMax ? countMaxedAspects(allAspects, playerAspects) : countUnlockedAspects(playerAspects);
+
+        int mythicTotal = (int) allAspects.stream().filter(a -> a.getRarity().equalsIgnoreCase("mythic")).count();
+        int mythicCount = progressBarShowMax ? countMaxedByRarity(allAspects, playerAspects, "mythic") : countUnlockedByRarity(allAspects, playerAspects, "mythic");
+
+        int fabledTotal = (int) allAspects.stream().filter(a -> a.getRarity().equalsIgnoreCase("fabled")).count();
+        int fabledCount = progressBarShowMax ? countMaxedByRarity(allAspects, playerAspects, "fabled") : countUnlockedByRarity(allAspects, playerAspects, "fabled");
+
+        int legendaryTotal = (int) allAspects.stream().filter(a -> a.getRarity().equalsIgnoreCase("legendary")).count();
+        int legendaryCount = progressBarShowMax ? countMaxedByRarity(allAspects, playerAspects, "legendary") : countUnlockedByRarity(allAspects, playerAspects, "legendary");
+
+        String suffix = progressBarShowMax ? " Max" : "";
+
+        // Total progress bar
+        drawProgressBarWithLabel(context, barX, barStartY, barWidth, 28, totalCount, totalAspects, "§6§lTotal" + suffix, 0xFF66CC66);
+        barStartY += 55;
+
+        // Rarity progress bars (muted colors) - increased spacing
+        drawProgressBarWithLabel(context, barX, barStartY, barWidth, 24, mythicCount, mythicTotal, "§5Mythic" + suffix, 0xFF9966CC);
+        barStartY += 48;
+
+        drawProgressBarWithLabel(context, barX, barStartY, barWidth, 24, fabledCount, fabledTotal, "§cFabled" + suffix, 0xFFCC6666);
+        barStartY += 48;
+
+        drawProgressBarWithLabel(context, barX, barStartY, barWidth, 24, legendaryCount, legendaryTotal, "§bLegendary" + suffix, 0xFF6699CC);
+        barStartY += 65;
+
+        // Per-class progress bars
+        drawCenteredText(context, "§e§lPER CLASS", centerX, barStartY);
+        barStartY += 35;
+
+        String[] classes = {"Warrior", "Shaman", "Mage", "Archer", "Assassin"};
+        for (String className : classes) {
+            int classTotal = (int) allAspects.stream().filter(a -> a.getRequiredClass().equalsIgnoreCase(className)).count();
+
+            // Use toggle to show either maxed or unlocked count
+            int classCount = progressBarShowMax
+                ? countMaxedForClassAndRarity(allAspects, playerAspects, className, null)
+                : countUnlockedForClassAndRarity(allAspects, playerAspects, className, null);
+
+            String classColor = switch (className) {
+                case "Warrior" -> "§c";
+                case "Shaman" -> "§b";
+                case "Mage" -> "§e";
+                case "Archer" -> "§d";
+                case "Assassin" -> "§5";
+                default -> "§7";
+            };
+
+            int fillColor = switch (className) {
+                case "Warrior" -> 0xFFCC6666;      // Muted red
+                case "Shaman" -> 0xFF6699CC;       // Muted light blue
+                case "Mage" -> 0xFFCCCC66;         // Muted yellow
+                case "Archer" -> 0xFFCC66CC;       // Muted pink
+                case "Assassin" -> 0xFF9966CC;     // Muted dark purple
+                default -> 0xFF666666;
+            };
+
+            drawProgressBarWithLabel(context, barX, barStartY, barWidth, 20, classCount, classTotal, classColor + className + suffix, fillColor);
+            barStartY += 44; // Increased spacing
+        }
+    }
+
+    private int countMaxedByRarity(List<ApiAspect> allAspects, List<Aspect> playerAspects, String rarity) {
+        int count = 0;
+        for (Aspect playerAspect : playerAspects) {
+            for (ApiAspect apiAspect : allAspects) {
+                if (!apiAspect.getName().equals(playerAspect.getName())) continue;
+                if (!apiAspect.getRarity().equalsIgnoreCase(rarity)) continue;
+
+                int maxAmount = switch (rarity.toLowerCase()) {
+                    case "mythic" -> 15;
+                    case "fabled" -> 75;
+                    case "legendary" -> 150;
+                    default -> 0;
+                };
+
+                if (playerAspect.getAmount() >= maxAmount) {
+                    count++;
+                }
+                break;
+            }
+        }
+        return count;
+    }
+
+    private int countUnlockedAspects(List<Aspect> playerAspects) {
+        return playerAspects.size();
+    }
+
+    private int countUnlockedByRarity(List<ApiAspect> allAspects, List<Aspect> playerAspects, String rarity) {
+        int count = 0;
+        for (Aspect playerAspect : playerAspects) {
+            for (ApiAspect apiAspect : allAspects) {
+                if (!apiAspect.getName().equals(playerAspect.getName())) continue;
+                if (apiAspect.getRarity().equalsIgnoreCase(rarity)) {
+                    count++;
+                }
+                break;
+            }
+        }
+        return count;
+    }
+
+    private int countUnlockedForClassAndRarity(List<ApiAspect> allAspects, List<Aspect> playerAspects, String className, String rarity) {
+        int count = 0;
+        for (Aspect playerAspect : playerAspects) {
+            for (ApiAspect apiAspect : allAspects) {
+                if (!apiAspect.getName().equals(playerAspect.getName())) continue;
+                if (!apiAspect.getRequiredClass().equalsIgnoreCase(className)) continue;
+                if (rarity != null && !apiAspect.getRarity().equalsIgnoreCase(rarity)) continue;
+                count++;
+                break;
+            }
+        }
+        return count;
+    }
+
+    private void drawProgressBarWithLabel(DrawContext context, int x, int y, int barWidth, int height, int current, int total, String label, int fillColor) {
+        double progress = total > 0 ? (double) current / total : 0;
+        int fillWidth = (int) (barWidth * progress);
+        boolean isMaxed = current >= total && total > 0;
+
+        // Label on left (move further left to avoid overlapping with bar)
+        // Add rainbow effect to label if maxed
+        if (isMaxed) {
+            drawRainbowText(context, label, x - 320, y + (height / 2) - 8);
+        } else {
+            drawLeftText(context, label, x - 320, y + (height / 2) - 8);
+        }
+
+        // Background using drawRect
+        drawRect(x, y, barWidth, height, 0xFF1a1a1a);
+
+        // Border - golden if maxed
+        int borderColor = isMaxed ? 0xFFFFD700 : 0xFF4e392d;
+        drawRect(x, y, barWidth, 2, borderColor); // top
+        drawRect(x, y + height - 2, barWidth, 2, borderColor); // bottom
+        drawRect(x, y, 2, height, borderColor); // left
+        drawRect(x + barWidth - 2, y, 2, height, borderColor); // right
+
+        // Fill - golden if maxed, otherwise normal color
+        if (fillWidth > 4) {
+            if (isMaxed) {
+                drawRect(x + 2, y + 2, fillWidth - 4, height - 4, 0xFFFFD700); // Golden fill
+            } else {
+                drawRect(x + 2, y + 2, fillWidth - 4, height - 4, fillColor);
+            }
+        }
+
+        // Stats on right - golden if maxed, just star (no 100%!)
+        String statsText;
+        if (isMaxed) {
+            statsText = "§6§l" + current + "§8/§6§l" + total + " §6§l★";
+        } else {
+            statsText = "§7" + current + "§8/§7" + total + " §8(§e" + String.format("%.1f", progress * 100) + "%§8)";
+        }
+        drawLeftText(context, statsText, x + barWidth + 20, y + (height / 2) - 8);
+    }
+
+    /**
+     * Draw text with rainbow color animation
+     */
+    private void drawRainbowText(DrawContext context, String text, int x, int y) {
+        if (ui == null) return;
+
+        long time = System.currentTimeMillis();
+        float animOffset = (time % 1500) / 1500f; // Full cycle every 1.5 seconds
+
+        // Rainbow colors for text
+        String[] colorCodes = {"§c", "§6", "§e", "§a", "§b", "§9", "§d"};
+
+        StringBuilder coloredText = new StringBuilder();
+        int charIndex = 0;
+
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+
+            // Skip formatting codes
+            if (c == '§' && i + 1 < text.length()) {
+                i++; // Skip the format character
+                continue;
+            }
+
+            // Calculate color for this character
+            int colorIdx = (int)((charIndex + animOffset * colorCodes.length) % colorCodes.length);
+            coloredText.append(colorCodes[colorIdx]).append(c);
+            charIndex++;
+        }
+
+        drawLeftText(context, coloredText.toString(), x, y);
+    }
+
+    /**
+     * Draw progress bars for the currently selected class showing All/Mythic/Fabled/Legendary maxed counts
+     * @return the Y position after drawing all bars
+     */
+    private int drawClassProgressBars(DrawContext context, List<ApiAspect> allAspects, List<Aspect> playerAspects, int centerX, int startY) {
+        int logicalW = getLogicalWidth();
+        int barWidth = Math.min(600, logicalW - 600);
+        int barX = centerX - barWidth / 2 + 50; // shift right for label space
+
+        String className = classFilter;
+        String classColor = switch (className) {
+            case "Warrior" -> "§c";
+            case "Shaman" -> "§b";
+            case "Mage" -> "§e";
+            case "Archer" -> "§d";
+            case "Assassin" -> "§5";
+            default -> "§7";
+        };
+
+        int fillColor = switch (className) {
+            case "Warrior" -> 0xFFCC6666;
+            case "Shaman" -> 0xFF6699CC;
+            case "Mage" -> 0xFFCCCC66;
+            case "Archer" -> 0xFFCC66CC;
+            case "Assassin" -> 0xFF9966CC;
+            default -> 0xFF666666;
+        };
+
+        // Calculate totals for this class based on mode
+        int allTotal = (int) allAspects.stream().filter(a -> a.getRequiredClass().equalsIgnoreCase(className)).count();
+        int allCount = progressBarShowMax
+            ? countMaxedForClassAndRarity(allAspects, playerAspects, className, null)
+            : countUnlockedForClassAndRarity(allAspects, playerAspects, className, null);
+
+        int mythicTotal = (int) allAspects.stream().filter(a -> a.getRequiredClass().equalsIgnoreCase(className) && a.getRarity().equalsIgnoreCase("mythic")).count();
+        int mythicCount = progressBarShowMax
+            ? countMaxedForClassAndRarity(allAspects, playerAspects, className, "mythic")
+            : countUnlockedForClassAndRarity(allAspects, playerAspects, className, "mythic");
+
+        int fabledTotal = (int) allAspects.stream().filter(a -> a.getRequiredClass().equalsIgnoreCase(className) && a.getRarity().equalsIgnoreCase("fabled")).count();
+        int fabledCount = progressBarShowMax
+            ? countMaxedForClassAndRarity(allAspects, playerAspects, className, "fabled")
+            : countUnlockedForClassAndRarity(allAspects, playerAspects, className, "fabled");
+
+        int legendaryTotal = (int) allAspects.stream().filter(a -> a.getRequiredClass().equalsIgnoreCase(className) && a.getRarity().equalsIgnoreCase("legendary")).count();
+        int legendaryCount = progressBarShowMax
+            ? countMaxedForClassAndRarity(allAspects, playerAspects, className, "legendary")
+            : countUnlockedForClassAndRarity(allAspects, playerAspects, className, "legendary");
+
+        int y = startY;
+
+        // All aspects bar
+        drawProgressBarWithLabel(context, barX, y, barWidth, 20, allCount, allTotal, classColor + "All " + className, fillColor);
+        y += 36; // Increased spacing
+
+        // Mythic bar
+        drawProgressBarWithLabel(context, barX, y, barWidth, 18, mythicCount, mythicTotal, "§5Mythic " + className, 0xFF9966CC);
+        y += 32; // Increased spacing
+
+        // Fabled bar
+        drawProgressBarWithLabel(context, barX, y, barWidth, 18, fabledCount, fabledTotal, "§cFabled " + className, 0xFFCC6666);
+        y += 32; // Increased spacing
+
+        // Legendary bar
+        drawProgressBarWithLabel(context, barX, y, barWidth, 18, legendaryCount, legendaryTotal, "§bLegendary " + className, 0xFF6699CC);
+        y += 32; // Increased spacing
+
+        return y;
+    }
+
+    /**
+     * Count maxed aspects for a specific class and optionally a specific rarity
+     */
+    private int countMaxedForClassAndRarity(List<ApiAspect> allAspects, List<Aspect> playerAspects, String className, String rarity) {
+        int count = 0;
+        for (Aspect playerAspect : playerAspects) {
+            for (ApiAspect apiAspect : allAspects) {
+                if (!apiAspect.getName().equals(playerAspect.getName())) continue;
+                if (!apiAspect.getRequiredClass().equalsIgnoreCase(className)) continue;
+                if (rarity != null && !apiAspect.getRarity().equalsIgnoreCase(rarity)) continue;
+
+                int maxAmount = switch (apiAspect.getRarity().toLowerCase()) {
+                    case "mythic" -> 15;
+                    case "fabled" -> 75;
+                    case "legendary" -> 150;
+                    default -> 0;
+                };
+
+                if (playerAspect.getAmount() >= maxAmount) {
+                    count++;
+                }
+                break;
+            }
+        }
+        return count;
+    }
+
+    private List<ApiAspect> getAspectsForClass(List<ApiAspect> allAspects, List<Aspect> playerAspects, String className) {
+        List<ApiAspect> filtered = new ArrayList<>();
+
+        for (ApiAspect aspect : allAspects) {
+            // Check if player has this aspect
+            Aspect playerAspect = null;
+            for (Aspect pa : playerAspects) {
+                if (pa.getName().equals(aspect.getName())) {
+                    playerAspect = pa;
+                    break;
+                }
+            }
+
+            if (playerAspect == null) continue; // Only show unlocked
+
+            // Check class
+            if (!aspect.getRequiredClass().equalsIgnoreCase(className)) continue;
+
+            // Check max filter
+            int maxAmount = switch (aspect.getRarity().toLowerCase()) {
+                case "mythic" -> 15;
+                case "fabled" -> 75;
+                case "legendary" -> 150;
+                default -> 0;
+            };
+
+            boolean isMaxed = playerAspect.getAmount() >= maxAmount;
+
+            if (maxFilter.equals("Max Only") && !isMaxed) continue;
+            if (maxFilter.equals("Not Max") && isMaxed) continue;
+            if (maxFilter.equals("Favorites") && !FavoriteAspectsData.INSTANCE.isFavorite(aspect.getName())) continue;
+
+            filtered.add(aspect);
+        }
+
+        // Sort by rarity: Mythic -> Fabled -> Legendary
+        filtered.sort((a, b) -> {
+            int rarityOrder1 = getRarityOrder(a.getRarity());
+            int rarityOrder2 = getRarityOrder(b.getRarity());
+            return Integer.compare(rarityOrder1, rarityOrder2);
+        });
+
+        return filtered;
+    }
+
+    private int getRarityOrder(String rarity) {
+        return switch (rarity.toLowerCase()) {
+            case "mythic" -> 0;
+            case "fabled" -> 1;
+            case "legendary" -> 2;
+            default -> 999;
+        };
+    }
+
+    private int drawAspectsByRarityForClass(DrawContext context, int x, int y, List<ApiAspect> aspects, List<Aspect> playerAspects, String rarity, String color, int colWidth, int mouseX, int mouseY) {
+        List<ApiAspect> filtered = aspects.stream()
+            .filter(a -> a.getRarity().equalsIgnoreCase(rarity))
+            .toList();
+
+        if (filtered.isEmpty()) return y;
+
+        int lineHeight = 35; // Logical spacing
+
+        for (ApiAspect aspect : filtered) {
+            // Find player progress
+            Aspect playerAspect = null;
+            for (Aspect pa : playerAspects) {
+                if (pa.getName().equals(aspect.getName())) {
+                    playerAspect = pa;
+                    break;
+                }
+            }
+
+            if (playerAspect == null) continue;
+
+            // Check if aspect is maxed
+            int maxAmount = switch (aspect.getRarity().toLowerCase()) {
+                case "mythic" -> 15;
+                case "fabled" -> 75;
+                case "legendary" -> 150;
+                default -> 0;
+            };
+            boolean isMaxed = playerAspect.getAmount() >= maxAmount;
+
+            // Truncate name by character count (logical coords)
+            int maxChars = Math.max(10, (colWidth - 80) / 12);
+            String displayName = aspect.getName();
+            if (displayName.length() > maxChars) {
+                displayName = displayName.substring(0, maxChars - 3) + "...";
+            }
+
+            // Check hover using full row width for easier hit detection (mouseX/Y are already logical)
+            // Hitbox aligned with text position (y is where text is drawn)
+            boolean isHovered = false;
+            if (mouseX >= x + 16 && mouseX <= x + colWidth - 16 &&
+                mouseY >= y - 10 && mouseY <= y + 25) {
+                hoveredMyAspect = aspect;
+                hoveredMyAspectProgress = playerAspect;
+                isHovered = true;
+            }
+
+            // Check if favorited
+            boolean isFavorite = FavoriteAspectsData.INSTANCE.isFavorite(aspect.getName());
+
+            // Show star: filled if favorite, empty if hovered but not favorite, nothing otherwise
+            String favoriteStar;
+            if (isFavorite) {
+                favoriteStar = " §e⭐";
+            } else if (isHovered) {
+                favoriteStar = " §7☆";
+            } else {
+                favoriteStar = "";
+            }
+
+            // Draw text at y position - rainbow for maxed aspects
+            if (isMaxed && ui != null) {
+                ui.drawText(displayName + favoriteStar, x + 45, y, CommonColors.RAINBOW, 3f);
+            } else {
+                drawLeftText(context, color + displayName + favoriteStar, x + 45, y);
+            }
+
+            // Draw flame icon
+            ItemStack flameItem = createAspectFlameIcon(aspect, isMaxed);
+            if (!flameItem.isEmpty() && ui != null) {
+                float flameScale = 0.6f;
+                int screenX = (int) ui.sx(x + 12);
+                int screenY = (int) ui.sy(y + 2); // Move flame up
+                context.getMatrices().pushMatrix();
+                context.getMatrices().scale(flameScale, flameScale);
+                context.drawItem(flameItem, (int)(screenX / flameScale), (int)(screenY / flameScale));
+                context.getMatrices().popMatrix();
+            }
+
+            y += lineHeight;
+        }
+
+        return y + 20; // Spacing after rarity group
+    }
+
+    private void renderMyAspectTooltip(DrawContext context, int mouseX, int mouseY) {
+        if (hoveredMyAspect == null || hoveredMyAspectProgress == null) return;
+
+        List<Text> tooltipLines = new ArrayList<>();
+
+        // Rarity color
+        String rarityColor = switch (hoveredMyAspect.getRarity().toLowerCase()) {
+            case "mythic" -> "§5";
+            case "fabled" -> "§c";
+            case "legendary" -> "§b";
+            default -> "§f";
+        };
+
+        tooltipLines.add(Text.literal(rarityColor + hoveredMyAspect.getName()));
+
+        // Show progress
+        int maxAmount = switch (hoveredMyAspect.getRarity().toLowerCase()) {
+            case "mythic" -> 15;
+            case "fabled" -> 75;
+            case "legendary" -> 150;
+            default -> 0;
+        };
+
+        int amount = hoveredMyAspectProgress.getAmount();
+        if (amount >= maxAmount) {
+            tooltipLines.add(Text.literal(rarityColor + "[MAX]"));
+        } else {
+            tooltipLines.add(Text.literal("§7Progress: §e" + amount + "§7/§e" + maxAmount));
+        }
+
+        // Add description for current tier
+        String description = getDescriptionForCurrentTier(hoveredMyAspect, amount);
+        if (description != null && !description.isEmpty()) {
+            tooltipLines.add(Text.literal(""));
+
+            // Strip Wynncraft symbols
+            String cleanDesc = stripWynncraftSymbols(description);
+
+            // Split by newlines first (for multiple features)
+            String[] descriptionLines = cleanDesc.split("\n");
+            for (String descLine : descriptionLines) {
+                if (descLine.trim().isEmpty()) continue;
+
+                // Word wrap each line individually
+                List<String> wrappedLines = wrapText(descLine.trim(), 200);
+                for (String line : wrappedLines) {
+                    tooltipLines.add(Text.literal("§7" + line));
+                }
+            }
+        }
+
+        context.drawTooltip(textRenderer, tooltipLines, mouseX, mouseY);
+    }
+
+    private String getDescriptionForCurrentTier(ApiAspect aspect, int currentAmount) {
+        if (aspect.getTiers() == null || aspect.getTiers().isEmpty()) return null;
+
+        // Find the highest tier the player has reached
+        String currentTierKey = null;
+        int highestThreshold = 0;
+
+        for (Map.Entry<String, ApiAspect.Tier> entry : aspect.getTiers().entrySet()) {
+            int threshold = entry.getValue().getThreshold();
+            if (currentAmount >= threshold && threshold >= highestThreshold) {
+                highestThreshold = threshold;
+                currentTierKey = entry.getKey();
+            }
+        }
+
+        if (currentTierKey == null) return null;
+
+        ApiAspect.Tier tier = aspect.getTiers().get(currentTierKey);
+        if (tier.getDescription() == null || tier.getDescription().isEmpty()) return null;
+
+        // Join description lines with newlines
+        return String.join("\n", tier.getDescription());
+    }
+
+    private void renderNavigation(DrawContext context, int mouseX, int mouseY) {
+        int logicalW = getLogicalWidth();
+        int logicalH = getLogicalHeight();
+        int centerX = logicalW / 2;
+        int navY = logicalH - 120; // Position from bottom in logical units
+
+        // Convert mouse to logical for hover checks
+        int logicalMouseX = (int)(mouseX * scaleFactor);
+        int logicalMouseY = (int)(mouseY * scaleFactor);
+
+        // Left arrow (always visible, circular) - fixed distance from center
+        int leftX = centerX - 400;
+        boolean hoverLeft = logicalMouseX >= leftX - 30 && logicalMouseX <= leftX + 200 &&
+                           logicalMouseY >= navY - 20 && logicalMouseY <= navY + 50;
+
+        drawCenteredText(context, hoverLeft ? "§6§l< Previous" : "§e§l< Previous", leftX, navY);
+
+        // Page indicator (centered)
+        String pageText = switch (currentPage) {
+            case 0 -> "Loot Pools";
+            case 1 -> {
+                // If viewing another player, show their name instead
+                if (!searchedPlayer.isEmpty() && searchedPlayerData != null) {
+                    yield searchedPlayer + "'s Aspects";
+                } else {
+                    yield "My Aspects";
+                }
+            }
+            case 2 -> "Gambits";
+            case 3 -> "Raid Loot";
+            case 4 -> "Explore";
+            case 5 -> "Leaderboard";
+            default -> "Unknown";
+        };
+        drawCenteredText(context, "§e" + pageText + " §7(" + (currentPage + 1) + "/" + (MAX_PAGE + 1) + ")", centerX, navY);
+
+        // Right arrow (always visible, circular) - fixed distance from center
+        int rightX = centerX + 400;
+        boolean hoverRight = logicalMouseX >= rightX - 100 && logicalMouseX <= rightX + 130 &&
+                            logicalMouseY >= navY - 20 && logicalMouseY <= navY + 50;
+
+        drawCenteredText(context, hoverRight ? "§6§lNext >" : "§e§lNext >", rightX, navY);
+
+        // Quick page buttons at the bottom
+        int buttonY = navY + 45;
+        int buttonWidth = 210;
+        int buttonHeight = 50;
+        int buttonSpacing = 10;
+        String[] pageNames = {"Loot Pools", "Aspects", "Gambits", "Raid Loot", "Explore", "Leaderboard"};
+        int totalButtonsWidth = (buttonWidth * 6) + (buttonSpacing * 5);
+        int buttonStartX = (logicalW - totalButtonsWidth) / 2;
+
+        for (int i = 0; i <= MAX_PAGE; i++) {
+            int bx = buttonStartX + (i * (buttonWidth + buttonSpacing));
+            boolean isCurrentPage = (currentPage == i);
+            boolean hovering = logicalMouseX >= bx && logicalMouseX <= bx + buttonWidth &&
+                              logicalMouseY >= buttonY && logicalMouseY <= buttonY + buttonHeight;
+
+            // Draw textured button
+            if (ui != null) {
+                ui.drawButtonFade(bx, buttonY, buttonWidth, buttonHeight, 12, hovering || isCurrentPage);
+            }
+
+            // Text
+            String text = isCurrentPage ? "§6§l" + pageNames[i] : (hovering ? "§e" + pageNames[i] : "§7" + pageNames[i]);
+            drawCenteredText(context, text, bx + buttonWidth / 2, buttonY + buttonHeight / 2);
+        }
+    }
+
+    @Override
+    public boolean mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
+        // Only handle scroll on loot pools page
+        if (currentPage == 0) {
+            // Convert screen coords to logical coords for comparison
+            double logicalMouseX = mouseX * scaleFactor;
+            double logicalMouseY = mouseY * scaleFactor;
+
+            // Find which column the mouse is over
+            for (int i = 0; i < 4; i++) {
+                if (logicalMouseX >= raidColumnX[i] && logicalMouseX <= raidColumnX[i] + raidColumnWidth[i] &&
+                    logicalMouseY >= raidContentStartY && logicalMouseY <= raidContentStartY + raidPanelHeight) {
+                    // Scroll this column (scale scroll amount for logical units)
+                    int scrollAmount = (int)(verticalAmount * 60); // 60 logical pixels per scroll tick
+                    raidScrollOffsets[i] -= scrollAmount;
+
+                    // Clamp to valid range
+                    int maxScroll = Math.max(0, raidContentHeights[i] - raidPanelHeight);
+                    if (raidScrollOffsets[i] < 0) raidScrollOffsets[i] = 0;
+                    if (raidScrollOffsets[i] > maxScroll) raidScrollOffsets[i] = maxScroll;
+
+                    return true;
+                }
+            }
+        }
+        return super.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount);
+    }
+
+    @Override
+    public boolean mouseClicked(Click click, boolean doubleClick) {
+        double mouseX = click.x();
+        double mouseY = click.y();
+        int button = click.button();
+
+        // Convert to logical coordinates
+        int logicalW = getLogicalWidth();
+        int logicalH = getLogicalHeight();
+        double logicalMouseX = mouseX * scaleFactor;
+        double logicalMouseY = mouseY * scaleFactor;
+
+        int centerX = logicalW / 2;
+        int navY = logicalH - 120;
+
+        // Check for left click on aspects to favorite them (click the star)
+        if (button == 0) {
+            // Check if clicking on loot pool aspect (page 0)
+            if (currentPage == 0 && hoveredAspect != null) {
+                FavoriteAspectsData.INSTANCE.toggleFavorite(hoveredAspect.name);
+                McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
+                return true;
+            }
+            // Check if clicking on my aspect (page 1)
+            if (currentPage == 1 && hoveredMyAspect != null) {
+                FavoriteAspectsData.INSTANCE.toggleFavorite(hoveredMyAspect.getName());
+                McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
+                return true;
+            }
+        }
+
+        // Check "Import Wynntils Favorites" button click (on Loot Pools and My Aspects pages)
+        if (currentPage == 0 || currentPage == 1) {
+            int importButtonWidth = 400;
+            int importButtonHeight = 44;
+            int importButtonX = 40;
+            int importButtonY = 14;
+
+            if (logicalMouseX >= importButtonX && logicalMouseX <= importButtonX + importButtonWidth &&
+                logicalMouseY >= importButtonY && logicalMouseY <= importButtonY + importButtonHeight) {
+                // Import favorites from Wynntils
+                int imported = FavoriteAspectsData.INSTANCE.importFromWynntils();
+                if (imported > 0) {
+                    importFeedback = "§aImported " + imported + " favorites!";
+                } else {
+                    importFeedback = "§7No new favorites to import";
+                }
+                importFeedbackTime = System.currentTimeMillis();
+                McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
+                return true;
+            }
+        }
+
+        // Check left arrow click (circular navigation) - using logical coords
+        int leftX = centerX - 400;
+        if (logicalMouseX >= leftX - 100 && logicalMouseX <= leftX + 100 &&
+            logicalMouseY >= navY - 30 && logicalMouseY <= navY + 50) {
+            currentPage = (currentPage - 1 + MAX_PAGE + 1) % (MAX_PAGE + 1);
+            McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
+            return true;
+        }
+
+        // Check right arrow click (circular navigation)
+        int rightX = centerX + 400;
+        if (logicalMouseX >= rightX - 100 && logicalMouseX <= rightX + 100 &&
+            logicalMouseY >= navY - 30 && logicalMouseY <= navY + 50) {
+            currentPage = (currentPage + 1) % (MAX_PAGE + 1);
+            McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
+            return true;
+        }
+
+        // Check quick page button clicks
+        int pageBtnY = navY + 45;
+        int pageBtnWidth = 165;
+        int pageBtnHeight = 40;
+        int pageBtnSpacing = 12;
+        int totalPageBtnsWidth = (pageBtnWidth * 6) + (pageBtnSpacing * 5);
+        int pageBtnStartX = (logicalW - totalPageBtnsWidth) / 2;
+
+        for (int i = 0; i <= MAX_PAGE; i++) {
+            int pbx = pageBtnStartX + (i * (pageBtnWidth + pageBtnSpacing));
+            if (logicalMouseX >= pbx && logicalMouseX <= pbx + pageBtnWidth &&
+                logicalMouseY >= pageBtnY && logicalMouseY <= pageBtnY + pageBtnHeight) {
+                if (currentPage != i) {
+                    currentPage = i;
+                    McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
+                }
+                return true;
+            }
+        }
+
+        // Check "Click to open Party Finder" click (on gambits page when no data)
+        if (currentPage == 2) {
+            GambitData gambitData = GambitData.INSTANCE;
+            if (!gambitData.hasToday() || gambitData.gambits.isEmpty()) {
+                int pfTextY = 180 + 200; // startY + 200 from renderGambitsPage
+                if (logicalMouseY >= pfTextY - 20 && logicalMouseY <= pfTextY + 30 &&
+                    logicalMouseX >= centerX - 400 && logicalMouseX <= centerX + 400) {
+                    // Open party finder
+                    if (client != null && client.player != null) {
+                        McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
+                        client.setScreen(null);
+                        client.player.networkHandler.sendChatCommand("pf");
+                    }
+                    return true;
+                }
+            }
+        }
+
+        // Check toggle clicks (on loot pools page) - using logical coords
+        if (currentPage == 0) {
+            int toggleWidth = 200;
+            int favToggleWidth = 260;
+            int toggleHeight = 44;
+            int toggleSpacing = 15;
+            int toggleY = 14;
+
+            // Favorite toggle (left of Hide Max)
+            int favToggleX = logicalW - toggleWidth - favToggleWidth - toggleSpacing - 60;
+            if (logicalMouseX >= favToggleX && logicalMouseX <= favToggleX + favToggleWidth &&
+                logicalMouseY >= toggleY && logicalMouseY <= toggleY + toggleHeight) {
+                showOnlyFavoritesInLootPools = !showOnlyFavoritesInLootPools;
+                McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
+                return true;
+            }
+
+            // Hide Max toggle
+            int toggleX = logicalW - toggleWidth - 60;
+            if (logicalMouseX >= toggleX && logicalMouseX <= toggleX + toggleWidth &&
+                logicalMouseY >= toggleY && logicalMouseY <= toggleY + toggleHeight) {
+                hideMaxInLootPools = !hideMaxInLootPools;
+                McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
+                return true;
+            }
+        }
+
+        // Check raid header clicks (on loot pools page) - using logical coords
+        if (currentPage == 0) {
+            int startY = getLootPoolStartY();
+            int columnSpacing = 30;
+            int columnWidth = getSafeColumnWidth(4, columnSpacing);
+            int totalWidth = (columnWidth * 4) + (columnSpacing * 3);
+            int startX = (logicalW - totalWidth) / 2;
+
+            String[] raids = {"NOTG", "NOL", "TCC", "TNA"};
+
+            for (int i = 0; i < 4; i++) {
+                int x = startX + (i * (columnWidth + columnSpacing));
+                int headerHeight = 120;
+
+                if (logicalMouseX >= x && logicalMouseX <= x + columnWidth &&
+                    logicalMouseY >= startY && logicalMouseY <= startY + headerHeight) {
+                    // Clicked on this raid header - open party finder for this raid
+                    joinRaidPartyFinder(raids[i]);
+                    McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
+                    return true;
+                }
+            }
+        }
+
+        // Check button clicks (on my aspects page - page 1)
+        if (currentPage == 1) {
+            // Class selector buttons (including Overview) - MUST match drawClassSelectorButtons dimensions
+            int classButtonWidth = 170;
+            int classButtonHeight = 40;
+            int classSpacing = 16;
+            int classY = 100; // matches drawClassSelectorButtons y param
+
+            String[] buttons = {"Overview", "Warrior", "Shaman", "Mage", "Archer", "Assassin"};
+            int totalClassWidth = (classButtonWidth * buttons.length) + (classSpacing * (buttons.length - 1));
+            int classStartX = centerX - totalClassWidth / 2;
+
+            for (int i = 0; i < buttons.length; i++) {
+                int x = classStartX + (i * (classButtonWidth + classSpacing));
+                // Use logical coords for click detection
+                if (logicalMouseX >= x && logicalMouseX <= x + classButtonWidth &&
+                    logicalMouseY >= classY && logicalMouseY <= classY + classButtonHeight) {
+                    if (i == 0) {
+                        showOverview = true;
+                    } else {
+                        showOverview = false;
+                        classFilter = buttons[i];
+                    }
+                    McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
+                    return true;
+                }
+            }
+
+            // Max filter buttons (only on class view, not overview) - MUST match drawMaxFilterButtons
+            if (!showOverview) {
+                int maxButtonWidth = 200;
+                int maxButtonHeight = 44;
+                int maxSpacing = 12;
+                int maxY = 180; // matches drawMaxFilterButtons y param
+
+                String[] maxFilters = {"All", "Max Only", "Not Max", "Favorites"};
+                int totalMaxWidth = (maxButtonWidth * maxFilters.length) + (maxSpacing * (maxFilters.length - 1));
+                int maxStartX = centerX - totalMaxWidth / 2;
+
+                for (int i = 0; i < maxFilters.length; i++) {
+                    int x = maxStartX + (i * (maxButtonWidth + maxSpacing));
+                    if (logicalMouseX >= x && logicalMouseX <= x + maxButtonWidth &&
+                        logicalMouseY >= maxY && logicalMouseY <= maxY + maxButtonHeight) {
+                        maxFilter = maxFilters[i];
+                        McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
+                        return true;
+                    }
+                }
+            }
+
+            // Check search box click (only on overview page) - MUST match renderMyAspectsPage
+            if (showOverview) {
+                // Progress bar mode toggle - matches drawOverview
+                int toggleWidth = 160;
+                int toggleHeight = 36;
+                int toggleX = centerX + 300;
+                int toggleY = 230; // startY (240) - 10
+
+                if (button == 0 && logicalMouseX >= toggleX && logicalMouseX <= toggleX + toggleWidth &&
+                    logicalMouseY >= toggleY && logicalMouseY <= toggleY + toggleHeight) {
+                    progressBarShowMax = !progressBarShowMax;
+                    McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
+                    return true;
+                }
+
+                int searchBoxWidth = 400;
+                int searchBoxHeight = 30;
+                int searchBoxX = centerX - searchBoxWidth / 2;
+                int searchBoxY = 160; // Matches renderMyAspectsPage
+
+                // Right-click to clear search box
+                if (button == 1 && logicalMouseX >= searchBoxX && logicalMouseX <= searchBoxX + searchBoxWidth &&
+                    logicalMouseY >= searchBoxY && logicalMouseY <= searchBoxY + searchBoxHeight) {
+                    searchInput = "";
+                    searchCursorPos = 0;
+                    return true;
+                }
+
+                // Left-click on search box
+                if (button == 0 && logicalMouseX >= searchBoxX && logicalMouseX <= searchBoxX + searchBoxWidth &&
+                    logicalMouseY >= searchBoxY && logicalMouseY <= searchBoxY + searchBoxHeight) {
+                    searchInputFocused = true;
+                    McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
+                    return true;
+                }
+
+                // Click on recent searches dropdown
+                if (button == 0 && searchInputFocused && searchInput.isEmpty() && !FavoriteAspectsData.INSTANCE.getRecentSearches().isEmpty()) {
+                    int dropdownY = searchBoxY + searchBoxHeight + 4;
+                    int lineHeight = 28;
+                    int yOffset = dropdownY + 4;
+
+                    for (int i = 0; i < Math.min(FavoriteAspectsData.INSTANCE.getRecentSearches().size(), MAX_RECENT_SEARCHES); i++) {
+                        if (logicalMouseX >= searchBoxX && logicalMouseX <= searchBoxX + searchBoxWidth &&
+                            logicalMouseY >= yOffset && logicalMouseY <= yOffset + lineHeight) {
+                            // Clicked on this recent search
+                            String selectedSearch = FavoriteAspectsData.INSTANCE.getRecentSearches().get(i);
+                            searchInput = selectedSearch;
+                            searchCursorPos = selectedSearch.length();
+                            performPlayerSearch(selectedSearch);
+                            searchInputFocused = false;
+                            McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
+                            return true;
+                        }
+                        yOffset += lineHeight;
+                    }
+                }
+
+                // Click outside search box/dropdown - unfocus
+            }
+        }
+
+        // Check raid toggle clicks on Raid Loot page (page 3)
+        if (currentPage == 3) {
+            // Raid toggle buttons - must match rendering sizes!
+            int toggleWidth = 220;
+            int toggleHeight = 50;
+            int toggleSpacing = 20;
+            int toggleY = 120;
+
+            int totalToggleWidth = (toggleWidth * 4) + (toggleSpacing * 3);
+            int toggleStartX = (logicalW - totalToggleWidth) / 2;
+
+            for (int i = 0; i < 4; i++) {
+                int x = toggleStartX + (i * (toggleWidth + toggleSpacing));
+                if (button == 0 && logicalMouseX >= x && logicalMouseX <= x + toggleWidth &&
+                    logicalMouseY >= toggleY && logicalMouseY <= toggleY + toggleHeight) {
+                    raidToggles[i] = !raidToggles[i];
+                    McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
+                    return true;
+                }
+            }
+
+            // Check "Show Rates" button click - must match rendering sizes!
+            int ratesButtonWidth = 450;
+            int ratesButtonHeight = 50;
+            int ratesButtonX = centerX - ratesButtonWidth / 2;
+            int ratesButtonY = 180;
+
+            if (button == 0 && logicalMouseX >= ratesButtonX && logicalMouseX <= ratesButtonX + ratesButtonWidth &&
+                logicalMouseY >= ratesButtonY && logicalMouseY <= ratesButtonY + ratesButtonHeight) {
+                showRates = !showRates;
+                McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
+                return true;
+            }
+        }
+
+        // Check filter button clicks on Explore page (page 4)
+        if (currentPage == 4) {
+            int filterButtonWidth = 300;
+            int filterButtonHeight = 50;
+            int filterSpacing = 30;
+            int filterY = 125;
+            int totalFilterWidth = (filterButtonWidth * 2) + filterSpacing;
+            int filterStartX = (logicalW - totalFilterWidth) / 2;
+
+            for (int i = 0; i < 2; i++) {
+                int fx = filterStartX + (i * (filterButtonWidth + filterSpacing));
+                if (button == 0 && logicalMouseX >= fx && logicalMouseX <= fx + filterButtonWidth &&
+                    logicalMouseY >= filterY && logicalMouseY <= filterY + filterButtonHeight) {
+                    exploreSortMode = i;
+                    McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
+                    return true;
+                }
+            }
+        }
+
+        // Check player entry clicks on Explore page (page 4)
+        if (currentPage == 4 && playerList != null && !playerList.isEmpty()) {
+            // Sort the list same as rendering
+            List<julianh06.wynnextras.features.profileviewer.data.PlayerListEntry> sortedList = new java.util.ArrayList<>(playerList);
+            if (exploreSortMode == 0) {
+                sortedList.sort((a, b) -> Integer.compare(b.getAspectCount(), a.getAspectCount()));
+            } else {
+                sortedList.sort((a, b) -> a.getPlayerName().compareToIgnoreCase(b.getPlayerName()));
+            }
+
+            int columnCount = 3;
+            int entryWidth = 280;
+            int entryHeight = 85;
+            int spacing = 30;
+            int startY = 190;
+            int totalWidth = (entryWidth * columnCount) + (spacing * (columnCount - 1));
+            int startX = (logicalW - totalWidth) / 2;
+
+            int perPage = 15;
+            int maxEntries = Math.min(sortedList.size(), perPage);
+
+            for (int i = 0; i < maxEntries; i++) {
+                julianh06.wynnextras.features.profileviewer.data.PlayerListEntry player = sortedList.get(i);
+
+                int row = i / columnCount;
+                int col = i % columnCount;
+                int x = startX + (col * (entryWidth + spacing));
+                int y = startY + (row * (entryHeight + spacing));
+
+                if (button == 0 && logicalMouseX >= x && logicalMouseX <= x + entryWidth &&
+                    logicalMouseY >= y && logicalMouseY <= y + entryHeight) {
+                    // Clicked on this player - go to My Aspects page and search for them
+                    currentPage = 1; // My Aspects page
+                    showOverview = true; // Show overview by default
+                    performPlayerSearch(player.getPlayerName());
+                    McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
+                    return true;
+                }
+            }
+        }
+
+        // Check player entry clicks on Leaderboard page (page 5)
+        if (currentPage == 5 && leaderboardList != null && !leaderboardList.isEmpty()) {
+            int entryWidth = 800;
+            int entryHeight = 50;
+            int spacing = 8;
+            int startY = 180;
+            int startX = centerX - entryWidth / 2;
+
+            for (int i = 0; i < leaderboardList.size(); i++) {
+                julianh06.wynnextras.features.profileviewer.data.LeaderboardEntry entry = leaderboardList.get(i);
+                int y = startY + (i * (entryHeight + spacing));
+
+                if (button == 0 && logicalMouseX >= startX && logicalMouseX <= startX + entryWidth &&
+                    logicalMouseY >= y && logicalMouseY <= y + entryHeight) {
+                    // Clicked on this player - go to My Aspects page and search for them
+                    currentPage = 1; // My Aspects page
+                    showOverview = true; // Show overview by default
+                    performPlayerSearch(entry.getPlayerName());
+                    McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
+                    return true;
+                }
+            }
+        }
+
+        // Check click on error message scan links (FORBIDDEN and NOT_FOUND) - works on any page
+        if (currentPage == 1) {
+            if (searchedPlayerStatus == WynncraftApiHandler.FetchStatus.FORBIDDEN && searchedPlayer.isEmpty()) {
+                boolean clickedError = logicalMouseY >= logicalH / 2 + 10 && logicalMouseY <= logicalH / 2 + 50 &&
+                                      logicalMouseX >= centerX - 400 && logicalMouseX <= centerX + 400;
+                if (clickedError) {
+                    if (client != null && client.player != null) {
+                        McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
+                        McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§eStarting aspect scan..."));
+                        client.setScreen(null);
+                        client.player.networkHandler.sendChatCommand("we aspects scan");
+                    }
+                    return true;
+                }
+            }
+
+            if (searchedPlayerStatus == WynncraftApiHandler.FetchStatus.NOT_FOUND) {
+                boolean clickedError = logicalMouseY >= logicalH / 2 + 10 && logicalMouseY <= logicalH / 2 + 50 &&
+                                      logicalMouseX >= centerX - 400 && logicalMouseX <= centerX + 400;
+                if (clickedError) {
+                    if (client != null && client.player != null) {
+                        McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
+                        McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§eStarting aspect scan..."));
+                        client.setScreen(null);
+                        client.player.networkHandler.sendChatCommand("we aspects scan");
+                    }
+                    return true;
+                }
+            }
+        }
+
+        // Check "Back to My Aspects" button click (on overview page when viewing another player) - page 1
+        if (currentPage == 1 && showOverview) {
+            // Click outside search box/dropdown - unfocus
+            if (button == 0 && searchInputFocused) {
+                int searchBoxWidth = 400;
+                int searchBoxHeight = 30;
+                int searchBoxX = centerX - searchBoxWidth / 2;
+                int searchBoxY = 160;
+                int dropdownY = searchBoxY + searchBoxHeight + 4;
+                int lineHeight = 28;
+                int dropdownHeight = Math.min(FavoriteAspectsData.INSTANCE.getRecentSearches().size(), MAX_RECENT_SEARCHES) * lineHeight + 8;
+                boolean clickedInDropdown = logicalMouseY >= dropdownY && logicalMouseY <= dropdownY + dropdownHeight &&
+                                           logicalMouseX >= searchBoxX && logicalMouseX <= searchBoxX + searchBoxWidth;
+
+                if (!clickedInDropdown && !(logicalMouseX >= searchBoxX && logicalMouseX <= searchBoxX + searchBoxWidth &&
+                    logicalMouseY >= searchBoxY && logicalMouseY <= searchBoxY + searchBoxHeight)) {
+                    searchInputFocused = false;
+                }
+            }
+
+            // Check "Back to My Aspects" button click (top right styled button)
+            if (!searchedPlayer.isEmpty()) {
+                int buttonWidth = 260;
+                int buttonHeight = 44;
+                int buttonX = logicalW - buttonWidth - 40;
+                int buttonY = 46;
+
+                if (logicalMouseX >= buttonX && logicalMouseX <= buttonX + buttonWidth &&
+                    logicalMouseY >= buttonY && logicalMouseY <= buttonY + buttonHeight) {
+                    // Reset to viewing own aspects
+                    searchedPlayer = "";
+                    searchedPlayerData = null;
+                    searchedPlayerStatus = null;
+                    searchInput = "";
+                    searchCursorPos = 0;
+                    McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
+                    return true;
+                }
+            }
+
+            // Check click on "scan your aspects" text - use logical coords (above navigation)
+            int scanTextY = logicalH - 165;
+            boolean clickedScan = logicalMouseY >= scanTextY - 20 && logicalMouseY <= scanTextY + 40 &&
+                                 logicalMouseX >= centerX - 400 && logicalMouseX <= centerX + 400;
+
+            if (clickedScan) {
+                // Run /we aspects scan command
+                if (client != null && client.player != null) {
+                    McUtils.playSoundUI(SoundEvents.UI_BUTTON_CLICK.value());
+                    McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§eStarting aspect scan..."));
+                    client.setScreen(null);
+                    client.player.networkHandler.sendChatCommand("we aspects scan");
+                }
+                return true;
+            }
+        }
+
+        return super.mouseClicked(click, doubleClick);
+    }
+
+    private void joinRaidPartyFinder(String raidCode) {
+        if (client == null || client.player == null) return;
+
+        // Close this screen
+        client.setScreen(null);
+
+        // Set the raid we want to join
+        pendingRaidJoin = raidCode;
+
+        // Open party finder
+        client.player.networkHandler.sendChatCommand("pf");
+
+        // Register tick listener to wait for party finder menu and click through
+        final AtomicBoolean clickedQueue = new AtomicBoolean(false);
+        final AtomicBoolean clickedRaid = new AtomicBoolean(false);
+        final int[] ticksSinceQueueClick = {0}; // Wait ticks after clicking queue
+
+        ClientTickEvents.END_CLIENT_TICK.register(clientTick -> {
+            if (pendingRaidJoin == null || clickedRaid.get()) {
+                return; // Done, listener will stay registered but do nothing
+            }
+
+            if (McUtils.player() == null || clientTick.currentScreen == null) return;
+
+            ScreenHandler menu = McUtils.containerMenu();
+            if (menu == null) return;
+
+            // Step 1: Click "Party Queue" button (slot 49)
+            if (!clickedQueue.get() && menu.slots.size() > 49) {
+                Slot slot = menu.getSlot(49);
+                if (slot != null && slot.getStack() != null && slot.getStack().getName() != null) {
+                    String name = slot.getStack().getName().getString();
+                    if (name.contains("Queue")) {
+                        if (debugMode) {
+                            McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§e[Debug] Clicking Party Queue (slot 49)"));
+                            System.out.println("[RaidDebug] Clicking Party Queue at slot 49");
+                        }
+                        clickOnSlot(49, menu.syncId, 0, menu.getStacks());
+                        clickedQueue.set(true);
+                        ticksSinceQueueClick[0] = 0;
+                        return;
+                    }
+                }
+            }
+
+            // Wait 8 ticks after clicking queue before clicking raid
+            if (clickedQueue.get() && !clickedRaid.get()) {
+                ticksSinceQueueClick[0]++;
+                if (ticksSinceQueueClick[0] < 8) {
+                    return; // Wait more
+                }
+            }
+
+            // Step 2: Click the specific raid button - search by name instead of hardcoded slot
+            if (clickedQueue.get() && !clickedRaid.get() && menu.slots.size() > 20) {
+                // Search for the raid by name in slots 10-20
+                String searchName = switch (pendingRaidJoin) {
+                    case "NOTG" -> "Nest of the Grootslangs";
+                    case "NOL" -> "Orphion's Nexus of Light";
+                    case "TCC" -> "The Canyon Colossus";
+                    case "TNA" -> "The Nameless Anomaly";
+                    default -> "";
+                };
+
+                if (debugMode) {
+                    McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§e[Debug] Searching for raid: " + searchName));
+                    System.out.println("[RaidDebug] Searching for raid: " + searchName);
+                }
+
+                for (int slotIdx = 10; slotIdx <= 20; slotIdx++) {
+                    if (menu.slots.size() <= slotIdx) continue;
+                    Slot slot = menu.getSlot(slotIdx);
+                    if (slot != null && slot.getStack() != null && slot.getStack().getName() != null) {
+                        String itemName = slot.getStack().getName().getString();
+                        if (debugMode) {
+                            System.out.println("[RaidDebug] Slot " + slotIdx + ": " + itemName);
+                        }
+                        if (itemName.contains(searchName) || itemName.contains(pendingRaidJoin)) {
+                            if (debugMode) {
+                                McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§e[Debug] Found " + pendingRaidJoin + " at slot " + slotIdx));
+                            }
+                            clickOnSlot(slotIdx, menu.syncId, 0, menu.getStacks());
+                            clickedRaid.set(true);
+                            pendingRaidJoin = null;
+                            return;
+                        }
+                    }
+                }
+
+                if (debugMode) {
+                    McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§c[Debug] Could not find raid " + pendingRaidJoin + " in menu"));
+                }
+            }
+        });
+    }
+
+    private ItemStack createAspectFlameIcon(ApiAspect apiAspect, boolean isMaxed) {
+        if (apiAspect == null || apiAspect.getIcon() == null) {
+            return ItemStack.EMPTY;
+        }
+
+        try {
+            ApiAspect.IconValue iv = apiAspect.getIcon().getValueObject();
+            if (iv == null) return ItemStack.EMPTY;
+
+            // Get the item from API
+            Identifier id = Identifier.of(iv.getId());
+            Item item = Registries.ITEM.get(id);
+            ItemStack stack = new ItemStack(item);
+
+            // Set custom model data (same as AspectsTabWidget in Profile Viewer)
+            if (iv.getCustomModelData() != null && iv.getCustomModelData().getRangeDispatch() != null) {
+                int cmd = iv.getCustomModelData().getRangeDispatch().getFirst() + (isMaxed ? 1 : 0);
+                stack.set(DataComponentTypes.CUSTOM_MODEL_DATA, new CustomModelDataComponent(List.of((float) cmd), List.of(), List.of(), List.of()));
+            }
+
+            return stack;
+        } catch (Exception e) {
+            return ItemStack.EMPTY;
+        }
+    }
+
+    private ApiAspect findApiAspectByName(String name) {
+        try {
+            List<ApiAspect> allAspects = WynncraftApiHandler.fetchAllAspects();
+            return allAspects.stream()
+                .filter(a -> a.getName().equals(name))
+                .findFirst()
+                .orElse(null);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+
+    private String truncate(String text, int maxLength) {
+        if (text.length() <= maxLength) return text;
+        return text.substring(0, maxLength - 3) + "...";
+    }
+
+    private String truncateToWidth(String text, int maxWidth) {
+        if (textRenderer.getWidth(text) <= maxWidth) {
+            return text;
+        }
+
+        // Binary search for the right length
+        int left = 0;
+        int right = text.length();
+        String ellipsis = "...";
+        int ellipsisWidth = textRenderer.getWidth(ellipsis);
+
+        while (left < right) {
+            int mid = (left + right + 1) / 2;
+            String truncated = text.substring(0, mid) + ellipsis;
+            if (textRenderer.getWidth(truncated) <= maxWidth) {
+                left = mid;
+            } else {
+                right = mid - 1;
+            }
+        }
+
+        if (left == 0) return "...";
+        return text.substring(0, left) + ellipsis;
+    }
+
+    private List<String> wrapText(String text, int maxWidth) {
+        List<String> lines = new ArrayList<>();
+        String[] words = text.split(" ");
+        StringBuilder currentLine = new StringBuilder();
+
+        for (String word : words) {
+            String testLine = currentLine.length() == 0 ? word : currentLine + " " + word;
+            if (textRenderer.getWidth(testLine) <= maxWidth) {
+                if (currentLine.length() > 0) currentLine.append(" ");
+                currentLine.append(word);
+            } else {
+                if (currentLine.length() > 0) {
+                    lines.add(currentLine.toString());
+                    currentLine = new StringBuilder(word);
+                } else {
+                    lines.add(word);
+                }
+            }
+        }
+
+        if (currentLine.length() > 0) {
+            lines.add(currentLine.toString());
+        }
+
+        return lines;
+    }
+
+    @Override
+    public boolean shouldPause() {
+        return false;
+    }
+
+    public static void open() {
+        MinecraftClient.getInstance().setScreen(new AspectScreenSimple());
+    }
+
+    public static void openLootPool() {
+        AspectScreenSimple screen = new AspectScreenSimple();
+        screen.currentPage = 0;
+        MinecraftClient.getInstance().setScreen(screen);
+    }
+
+    public static void openMyAspects() {
+        AspectScreenSimple screen = new AspectScreenSimple();
+        screen.currentPage = 1;
+        MinecraftClient.getInstance().setScreen(screen);
+    }
+
+    public static void openGambits() {
+        AspectScreenSimple screen = new AspectScreenSimple();
+        screen.currentPage = 2; // Updated after page reorder
+        MinecraftClient.getInstance().setScreen(screen);
+    }
+
+    public static void openRaidLoot() {
+        AspectScreenSimple screen = new AspectScreenSimple();
+        screen.currentPage = 3;
+        MinecraftClient.getInstance().setScreen(screen);
+    }
+
+    public static void openExplore() {
+        AspectScreenSimple screen = new AspectScreenSimple();
+        screen.currentPage = 4;
+        MinecraftClient.getInstance().setScreen(screen);
+    }
+
+    public static void openLeaderboard() {
+        AspectScreenSimple screen = new AspectScreenSimple();
+        screen.currentPage = 5;
+        MinecraftClient.getInstance().setScreen(screen);
+    }
+
+    public static void openPlayer(String playerName) {
+        AspectScreenSimple screen = new AspectScreenSimple();
+        screen.currentPage = 1; // My Aspects page
+        screen.searchInput = playerName;
+        screen.performPlayerSearch(playerName);
+        MinecraftClient.getInstance().setScreen(screen);
+    }
+
+    public static void toggleDebug() {
+        debugMode = !debugMode;
+        if (debugMode) {
+            McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§aRaid slot debug mode ENABLED"));
+            System.out.println("[WynnExtras] Raid debug mode enabled");
+        } else {
+            McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§cRaid slot debug mode DISABLED"));
+            System.out.println("[WynnExtras] Raid debug mode disabled");
+        }
+    }
+
+    @Override
+    public boolean charTyped(CharInput input) {
+        char chr = (char) input.codepoint();
+        if (searchInputFocused) {
+            // Insert character at cursor position
+            searchInput = searchInput.substring(0, searchCursorPos) + chr + searchInput.substring(searchCursorPos);
+            searchCursorPos++;
+            return true;
+        }
+        return super.charTyped(input);
+    }
+
+    @Override
+    public boolean keyPressed(KeyInput input) {
+        int keyCode = input.key();
+        if (searchInputFocused) {
+            if (keyCode == 259) { // Backspace
+                if (searchCursorPos > 0) {
+                    searchInput = searchInput.substring(0, searchCursorPos - 1) + searchInput.substring(searchCursorPos);
+                    searchCursorPos--;
+                }
+                return true;
+            } else if (keyCode == 261) { // Delete
+                if (searchCursorPos < searchInput.length()) {
+                    searchInput = searchInput.substring(0, searchCursorPos) + searchInput.substring(searchCursorPos + 1);
+                }
+                return true;
+            } else if (keyCode == 263) { // Left arrow
+                if (searchCursorPos > 0) {
+                    searchCursorPos--;
+                }
+                return true;
+            } else if (keyCode == 262) { // Right arrow
+                if (searchCursorPos < searchInput.length()) {
+                    searchCursorPos++;
+                }
+                return true;
+            } else if (keyCode == 257 || keyCode == 335) { // Enter or numpad enter
+                // Trigger search
+                if (!searchInput.isEmpty()) {
+                    performPlayerSearch(searchInput);
+                    searchInputFocused = false;
+                }
+                return true;
+            } else if (keyCode == 256) { // Escape
+                searchInputFocused = false;
+                return false; // Let it close the screen
+            }
+            return true;
+        }
+        return super.keyPressed(input);
+    }
+
+    private void renderExplorePage(DrawContext context, int mouseX, int mouseY) {
+        int logicalW = getLogicalWidth();
+        int logicalH = getLogicalHeight();
+        int centerX = logicalW / 2;
+
+        // Title
+        drawCenteredText(context, "§6§lEXPLORE PLAYERS", centerX, 60);
+        drawCenteredText(context, "§7Browse all players who have scanned their aspects", centerX, 110);
+
+        // Fetch player list on first load
+        if (!fetchedPlayerList) {
+            fetchedPlayerList = true;
+            WynncraftApiHandler.fetchPlayerList().thenAccept(result -> {
+                playerList = result;
+            });
+        }
+
+        // Show loading or data
+        if (playerList == null) {
+            drawCenteredText(context, "§eLoading players...", centerX, 200);
+            return;
+        }
+
+        if (playerList.isEmpty()) {
+            drawCenteredText(context, "§cNo players found", centerX, 200);
+            return;
+        }
+
+        // Convert mouse to logical
+        int logicalMouseX = (int)(mouseX * scaleFactor);
+        int logicalMouseY = (int)(mouseY * scaleFactor);
+
+        // Sort filter buttons
+        int filterButtonWidth = 300;
+        int filterButtonHeight = 50;
+        int filterSpacing = 30;
+        int filterY = 125;
+        int totalFilterWidth = (filterButtonWidth * 2) + filterSpacing;
+        int filterStartX = (logicalW - totalFilterWidth) / 2;
+
+        String[] filterNames = {"Most Aspects", "Username (A-Z)"};
+        for (int i = 0; i < 2; i++) {
+            int fx = filterStartX + (i * (filterButtonWidth + filterSpacing));
+            boolean active = exploreSortMode == i;
+            boolean hovering = logicalMouseX >= fx && logicalMouseX <= fx + filterButtonWidth &&
+                              logicalMouseY >= filterY && logicalMouseY <= filterY + filterButtonHeight;
+
+            // Draw textured button
+            if (ui != null) {
+                ui.drawButtonFade(fx, filterY, filterButtonWidth, filterButtonHeight, 12, hovering || active);
+            }
+
+            String text = active ? "§6§l" + filterNames[i] : "§7" + filterNames[i];
+            drawCenteredText(context, text, fx + filterButtonWidth / 2, filterY + filterButtonHeight / 2);
+        }
+
+        // Sort the player list based on mode
+        List<julianh06.wynnextras.features.profileviewer.data.PlayerListEntry> sortedList = new java.util.ArrayList<>(playerList);
+        if (exploreSortMode == 0) {
+            // Sort by most aspects (descending)
+            sortedList.sort((a, b) -> Integer.compare(b.getAspectCount(), a.getAspectCount()));
+        } else {
+            // Sort by username (A-Z)
+            sortedList.sort((a, b) -> a.getPlayerName().compareToIgnoreCase(b.getPlayerName()));
+        }
+
+        // Display players in a grid - 3 columns
+        int columnCount = 3;
+        int entryWidth = 280;
+        int entryHeight = 85;
+        int spacing = 30;
+        int startY = 190;
+
+        int totalWidth = (entryWidth * columnCount) + (spacing * (columnCount - 1));
+        int startX = (logicalW - totalWidth) / 2;
+
+        int perPage = 15; // 5 rows × 3 columns
+        int maxEntries = Math.min(sortedList.size(), perPage);
+
+        for (int i = 0; i < maxEntries; i++) {
+            julianh06.wynnextras.features.profileviewer.data.PlayerListEntry player = sortedList.get(i);
+
+            int row = i / columnCount;
+            int col = i % columnCount;
+            int x = startX + (col * (entryWidth + spacing));
+            int y = startY + (row * (entryHeight + spacing));
+
+            // Check if hovering
+            boolean hovering = logicalMouseX >= x && logicalMouseX <= x + entryWidth &&
+                              logicalMouseY >= y && logicalMouseY <= y + entryHeight;
+
+            // Background box (darker when hovering)
+            int bgColor = hovering ? 0xCC1a1a1a : 0xAA000000;
+            drawRect(x, y, entryWidth, entryHeight, bgColor);
+
+            // Border (golden when hovering)
+            int borderColor = hovering ? 0xFFFFAA00 : 0xFF4e392d;
+            drawRect(x, y, entryWidth, 3, borderColor); // top
+            drawRect(x, y + entryHeight - 3, entryWidth, 3, borderColor); // bottom
+            drawRect(x, y, 3, entryHeight, borderColor); // left
+            drawRect(x + entryWidth - 3, y, 3, entryHeight, borderColor); // right
+
+            // Player name (centered, larger)
+            drawCenteredText(context, "§6§l" + player.getPlayerName(), x + entryWidth / 2, y + 25);
+
+            // Aspect count - show "Total | Max" format if max count is available
+            int maxCount = player.getMaxAspectCount();
+            if (maxCount > 0) {
+                drawCenteredText(context, "§e" + player.getAspectCount() + " §7Total §8| §a" + maxCount + " §7Max", x + entryWidth / 2, y + 60);
+            } else {
+                drawCenteredText(context, "§e" + player.getAspectCount() + " §7aspects", x + entryWidth / 2, y + 60);
+            }
+        }
+
+        // Instructions above navigation
+        drawCenteredText(context, "§7Click on a player to view their aspects", centerX, logicalH - 165);
+    }
+
+    private void renderLeaderboardPage(DrawContext context, int mouseX, int mouseY) {
+        int logicalW = getLogicalWidth();
+        int logicalH = getLogicalHeight();
+        int centerX = logicalW / 2;
+
+        // Title
+        drawCenteredText(context, "§6§lLEADERBOARD", centerX, 60);
+        drawCenteredText(context, "§7Top 15 players with the most maxed aspects", centerX, 110);
+
+        // Fetch leaderboard on first load
+        if (!fetchedLeaderboard) {
+            fetchedLeaderboard = true;
+            WynncraftApiHandler.fetchLeaderboard(15).thenAccept(result -> {
+                leaderboardList = result;
+            });
+        }
+
+        // Show loading or data
+        if (leaderboardList == null) {
+            drawCenteredText(context, "§eLoading leaderboard...", centerX, 200);
+            return;
+        }
+
+        if (leaderboardList.isEmpty()) {
+            drawCenteredText(context, "§cNo leaderboard data", centerX, 200);
+            return;
+        }
+
+        // Display leaderboard entries
+        int entryWidth = 800;
+        int entryHeight = 50;
+        int spacing = 8;
+        int startY = 180;
+        int startX = centerX - entryWidth / 2;
+
+        // Convert mouse to logical
+        int logicalMouseX = (int)(mouseX * scaleFactor);
+        int logicalMouseY = (int)(mouseY * scaleFactor);
+
+        for (int i = 0; i < leaderboardList.size(); i++) {
+            julianh06.wynnextras.features.profileviewer.data.LeaderboardEntry entry = leaderboardList.get(i);
+            int y = startY + (i * (entryHeight + spacing));
+
+            // Check if hovering
+            boolean hovering = logicalMouseX >= startX && logicalMouseX <= startX + entryWidth &&
+                              logicalMouseY >= y && logicalMouseY <= y + entryHeight;
+
+            // Background box (darker when hovering)
+            int bgColor = hovering ? 0xCC1a1a1a : 0xAA000000;
+            drawRect(startX, y, entryWidth, entryHeight, bgColor);
+
+            // Border (golden for top 3, normal otherwise)
+            int borderColor;
+            if (i == 0) {
+                borderColor = 0xFFFFD700; // Gold for 1st
+            } else if (i == 1) {
+                borderColor = 0xFFC0C0C0; // Silver for 2nd
+            } else if (i == 2) {
+                borderColor = 0xFFCD7F32; // Bronze for 3rd
+            } else if (hovering) {
+                borderColor = 0xFFFFAA00; // Golden when hovering
+            } else {
+                borderColor = 0xFF4e392d; // Normal
+            }
+
+            drawRect(startX, y, entryWidth, 3, borderColor); // top
+            drawRect(startX, y + entryHeight - 3, entryWidth, 3, borderColor); // bottom
+            drawRect(startX, y, 3, entryHeight, borderColor); // left
+            drawRect(startX + entryWidth - 3, y, 3, entryHeight, borderColor); // right
+
+            // Rank (left)
+            String rankText = "§7#" + (i + 1);
+            if (i == 0) rankText = "§6§l#1";
+            else if (i == 1) rankText = "§f§l#2";
+            else if (i == 2) rankText = "§6§l#3";
+
+            drawLeftText(context, rankText, startX + 30, y + entryHeight / 2 - 5);
+
+            // Player name (center-left)
+            drawLeftText(context, "§6" + entry.getPlayerName(), startX + 120, y + entryHeight / 2 - 5);
+
+            // Max aspect count (right)
+            String countText = "§a§l" + entry.getMaxAspectCount() + " §7maxed";
+            drawLeftText(context, countText, startX + entryWidth - 200, y + entryHeight / 2 - 5);
+        }
+
+        // Instructions above navigation
+        drawCenteredText(context, "§7Click on a player to view their aspects", centerX, logicalH - 165);
+    }
+
+    private void renderRaidLootPage(DrawContext context, int mouseX, int mouseY) {
+        int logicalW = getLogicalWidth();
+        int logicalH = getLogicalHeight();
+        int centerX = logicalW / 2;
+
+        // Convert mouse to logical
+        int logicalMouseX = (int)(mouseX * scaleFactor);
+        int logicalMouseY = (int)(mouseY * scaleFactor);
+
+        // Title
+        drawCenteredText(context, "§6§lRAID LOOT TRACKER", centerX, 60);
+
+        // Raid toggles (4 buttons in a row)
+        int toggleWidth = 220;
+        int toggleHeight = 50;
+        int toggleSpacing = 20;
+        int toggleY = 120;
+        String[] raidNames = {"NOTG", "NOL", "TCC", "TNA"};
+        String[] raidColors = {"§5", "§b", "§c", "§e"};
+
+        int totalToggleWidth = (toggleWidth * 4) + (toggleSpacing * 3);
+        int toggleStartX = (logicalW - totalToggleWidth) / 2;
+
+        for (int i = 0; i < 4; i++) {
+            int x = toggleStartX + (i * (toggleWidth + toggleSpacing));
+            boolean active = raidToggles[i];
+            boolean hovering = logicalMouseX >= x && logicalMouseX <= x + toggleWidth &&
+                              logicalMouseY >= toggleY && logicalMouseY <= toggleY + toggleHeight;
+
+            // Draw textured button
+            if (ui != null) {
+                ui.drawButtonFade(x, toggleY, toggleWidth, toggleHeight, 12, hovering || active);
+            }
+
+            // Text - centered in button
+            String text = active ? raidColors[i] + "§l" + raidNames[i] : "§7" + raidNames[i];
+            drawCenteredText(context, text, x + toggleWidth / 2, toggleY + toggleHeight / 2);
+        }
+
+        // Show Rates button
+        int ratesButtonWidth = 450;
+        int ratesButtonHeight = 50;
+        int ratesButtonX = centerX - ratesButtonWidth / 2;
+        int ratesButtonY = 180;
+        boolean hoveringRates = logicalMouseX >= ratesButtonX && logicalMouseX <= ratesButtonX + ratesButtonWidth &&
+                               logicalMouseY >= ratesButtonY && logicalMouseY <= ratesButtonY + ratesButtonHeight;
+
+        // Draw textured button
+        if (ui != null) {
+            ui.drawButtonFade(ratesButtonX, ratesButtonY, ratesButtonWidth, ratesButtonHeight, 12, hoveringRates);
+        }
+
+        String ratesText = showRates ? "§a§lShowing: Average/Run" : "§e§lShowing: Totals";
+        drawCenteredText(context, ratesText, ratesButtonX + ratesButtonWidth / 2, ratesButtonY + ratesButtonHeight / 2);
+
+        // Get loot tracker data
+        RaidLootData lootData = RaidLootConfig.INSTANCE.data;
+
+        // Calculate combined stats based on selected raids
+        RaidLootData.RaidSpecificLoot combinedStats = new RaidLootData.RaidSpecificLoot();
+        int totalRuns = 0;
+
+        String[] raidCodes = {"NOTG", "NOL", "TCC", "TNA"};
+        for (int i = 0; i < 4; i++) {
+            if (raidToggles[i]) {
+                RaidLootData.RaidSpecificLoot raidStats = lootData.perRaidData.get(raidCodes[i]);
+                if (raidStats != null) {
+                    combinedStats.emeraldBlocks += raidStats.emeraldBlocks;
+                    combinedStats.liquidEmeralds += raidStats.liquidEmeralds;
+                    combinedStats.amplifierTier1 += raidStats.amplifierTier1;
+                    combinedStats.amplifierTier2 += raidStats.amplifierTier2;
+                    combinedStats.amplifierTier3 += raidStats.amplifierTier3;
+                    combinedStats.totalBags += raidStats.totalBags;
+                    combinedStats.stuffedBags += raidStats.stuffedBags;
+                    combinedStats.packedBags += raidStats.packedBags;
+                    combinedStats.variedBags += raidStats.variedBags;
+                    combinedStats.totalTomes += raidStats.totalTomes;
+                    combinedStats.mythicTomes += raidStats.mythicTomes;
+                    combinedStats.fabledTomes += raidStats.fabledTomes;
+                    combinedStats.totalCharms += raidStats.totalCharms;
+                    combinedStats.completionCount += raidStats.completionCount;
+                }
+            }
+        }
+        totalRuns = combinedStats.completionCount;
+
+        // Display stats
+        int startY = 260;
+        int lineHeight = 35;
+
+        drawCenteredText(context, "§6§lSTATISTICS", centerX, startY);
+        startY += 50;
+
+        // Calculate emeralds
+        long totalEmeralds = (combinedStats.liquidEmeralds * 64 * 64) + (combinedStats.emeraldBlocks * 64);
+        long stacks = totalEmeralds / 262144;
+        long remainingAfterStx = totalEmeralds % 262144;
+        long le = remainingAfterStx / 4096;
+        long remainingAfterLE = remainingAfterStx % 4096;
+        long eb = remainingAfterLE / 64;
+
+        if (showRates && totalRuns > 0) {
+            // Show averages per run
+            drawCenteredText(context, "§6§lTotal Runs: §f" + totalRuns, centerX, startY);
+            startY += lineHeight;
+
+            // Calculate total LE (including stx converted to LE)
+            long totalLeValue = (stacks * 64) + le;
+            double avgLe = (double) totalLeValue / totalRuns;
+
+            String emeraldAvgText;
+            if (avgLe >= 64) {
+                // Show in stx if average is at least 1 stx (64 LE)
+                emeraldAvgText = String.format("%.2fstx", avgLe / 64);
+            } else {
+                emeraldAvgText = String.format("%.1fle", avgLe);
+            }
+            drawCenteredText(context, "§a§lEmeralds/Run: §f" + emeraldAvgText, centerX, startY);
+            startY += lineHeight;
+
+            drawCenteredText(context, "§e§lAmplifiers/Run: §f" + String.format("%.2f", (double)combinedStats.getTotalAmplifiers() / totalRuns), centerX, startY);
+            startY += lineHeight + 8;
+
+            drawCenteredText(context, "§b§lBags/Run: §f" + String.format("%.2f", (double)combinedStats.totalBags / totalRuns), centerX, startY);
+            startY += lineHeight + 8;
+
+            drawCenteredText(context, "§d§lTomes/Run: §f" + String.format("%.2f", (double)combinedStats.totalTomes / totalRuns) + " §7(§5" + String.format("%.2f", (double)combinedStats.mythicTomes / totalRuns) + " §7mythic§7)", centerX, startY);
+            startY += lineHeight + 8;
+
+            drawCenteredText(context, "§5§lAspects/Run: §f" + String.format("%.2f", (double)combinedStats.totalAspects / totalRuns) + " §7(§5" + String.format("%.2f", (double)combinedStats.mythicAspects / totalRuns) + " §7mythic§7)", centerX, startY);
+            startY += lineHeight + 25;
+
+        } else {
+            // Show totals
+            drawCenteredText(context, "§6§lTotal Runs: §f" + totalRuns, centerX, startY);
+            startY += lineHeight;
+
+            // Build emerald text - always show stx + le if stx exists
+            StringBuilder emeraldText = new StringBuilder();
+            if (stacks > 0) {
+                emeraldText.append(stacks).append("stx");
+                if (le > 0) {
+                    emeraldText.append(" + ").append(le).append("le");
+                }
+            } else if (le > 0) {
+                emeraldText.append(le).append("le");
+            } else {
+                emeraldText.append(eb).append("eb");
+            }
+            drawCenteredText(context, "§a§lEmeralds: §f" + emeraldText.toString(), centerX, startY);
+            startY += lineHeight;
+
+            drawCenteredText(context, "§e§lAmplifiers: §f" + combinedStats.getTotalAmplifiers() + " §7(I: " + combinedStats.amplifierTier1 + " | II: " + combinedStats.amplifierTier2 + " | III: " + combinedStats.amplifierTier3 + ")", centerX, startY);
+            startY += lineHeight + 8;
+
+            drawCenteredText(context, "§b§lBags: §f" + combinedStats.totalBags + " §7(Stuffed: " + combinedStats.stuffedBags + " | Packed: " + combinedStats.packedBags + " | Varied: " + combinedStats.variedBags + ")", centerX, startY);
+            startY += lineHeight + 8;
+
+            drawCenteredText(context, "§d§lTomes: §f" + combinedStats.totalTomes + " §7(§5" + combinedStats.mythicTomes + " §7mythic, §d" + combinedStats.fabledTomes + " §7fabled§7)", centerX, startY);
+            startY += lineHeight + 8;
+
+            drawCenteredText(context, "§5§lAspects: §f" + combinedStats.totalAspects + " §7(§5" + combinedStats.mythicAspects + " §7mythic, §c" + combinedStats.fabledAspects + " §7fabled, §b" + combinedStats.legendaryAspects + " §7legendary§7)", centerX, startY);
+            startY += lineHeight + 25;
+        }
+
+        // Per-raid breakdown
+        if (raidToggles[0] || raidToggles[1] || raidToggles[2] || raidToggles[3]) {
+            drawCenteredText(context, "§e§lPER-RAID BREAKDOWN", centerX, startY);
+            startY += 40;
+
+            for (int i = 0; i < 4; i++) {
+                if (!raidToggles[i]) continue;
+
+                RaidLootData.RaidSpecificLoot raidStats = lootData.perRaidData.get(raidCodes[i]);
+                if (raidStats == null) {
+                    drawCenteredText(context, raidColors[i] + "§l" + raidNames[i] + ": §7No data", centerX, startY);
+                    startY += 30;
+                    continue;
+                }
+
+                int runs = raidStats.completionCount;
+                long raidTotalEmeralds = (raidStats.liquidEmeralds * 64 * 64) + (raidStats.emeraldBlocks * 64);
+                long raidStacks = raidTotalEmeralds / 262144;
+                long raidRemaining = raidTotalEmeralds % 262144;
+                long raidLe = raidRemaining / 4096;
+                long raidRemaining2 = raidRemaining % 4096;
+                long raidEb = raidRemaining2 / 64;
+
+                if (showRates && runs > 0) {
+                    // Calculate total LE (including stx converted to LE)
+                    // 1 stx = 64 LE, so totalLE = (stacks * 64) + remainderLE
+                    long totalLeValue = (raidStacks * 64) + raidLe;
+                    double avgLe = (double) totalLeValue / runs;
+
+                    String emeraldText;
+                    if (avgLe >= 64) {
+                        // Show in stx if average is at least 1 stx (64 LE)
+                        emeraldText = String.format("%.2fstx/run", avgLe / 64);
+                    } else {
+                        emeraldText = String.format("%.1fle/run", avgLe);
+                    }
+                    drawCenteredText(context, raidColors[i] + "§l" + raidNames[i] + ": §f" + runs + " runs §8| §a" + emeraldText, centerX, startY);
+                } else {
+                    // Show totals - always show stx + le if both exist
+                    String emeraldText;
+                    if (raidStacks > 0 && raidLe > 0) {
+                        emeraldText = raidStacks + "stx + " + raidLe + "le";
+                    } else if (raidStacks > 0) {
+                        emeraldText = raidStacks + "stx";
+                    } else if (raidLe > 0) {
+                        emeraldText = raidLe + "le";
+                    } else {
+                        emeraldText = raidEb + "eb";
+                    }
+                    drawCenteredText(context, raidColors[i] + "§l" + raidNames[i] + ": §f" + runs + " runs §8| §a" + emeraldText + " total", centerX, startY);
+                }
+                startY += 30;
+            }
+        }
+    }
+
+    private void performPlayerSearch(String playerName) {
+        searchedPlayer = playerName;
+        searchedPlayerData = null;
+        searchedPlayerStatus = null; // null = loading
+
+        String requestingUUID = McUtils.player() != null ? McUtils.player().getUuidAsString() : null;
+        final String expectedPlayer = playerName; // Capture to detect race condition
+
+        // First convert username to UUID
+        WynncraftApiHandler.fetchUUID(playerName).thenCompose(rawUUID -> {
+            // Check if search target changed while we were fetching UUID
+            if (!expectedPlayer.equals(searchedPlayer)) {
+                return CompletableFuture.completedFuture(null);
+            }
+            if (rawUUID == null) {
+                searchedPlayerStatus = WynncraftApiHandler.FetchStatus.NOT_FOUND;
+                return CompletableFuture.completedFuture(null);
+            }
+
+            // Format UUID and fetch aspect data
+            String formattedUUID = WynncraftApiHandler.formatUUID(rawUUID);
+            return WynncraftApiHandler.fetchPlayerAspectData(formattedUUID, requestingUUID);
+        }).thenAccept(result -> {
+            // Only update if we're still searching for the same player
+            if (!expectedPlayer.equals(searchedPlayer)) return;
+            if (result == null) return;
+            if (result.status() != null) {
+                if (result.status() == WynncraftApiHandler.FetchStatus.OK) {
+                    searchedPlayerData = result.user();
+                    // Add to recent searches on success
+                    addToRecentSearches(playerName);
+                }
+                searchedPlayerStatus = result.status();
+            }
+        }).exceptionally(ex -> {
+            // Only log/update if we're still searching for the same player
+            if (expectedPlayer.equals(searchedPlayer)) {
+                System.err.println("[WynnExtras] Error fetching aspects for " + playerName + ": " + ex.getMessage());
+                searchedPlayerStatus = WynncraftApiHandler.FetchStatus.UNKNOWN_ERROR;
+            }
+            return null;
+        });
+    }
+
+    private void addToRecentSearches(String playerName) {
+        // Use FavoriteAspectsData for persistence
+        FavoriteAspectsData.INSTANCE.addRecentSearch(playerName);
+    }
+}

--- a/src/main/java/julianh06/wynnextras/features/aspects/FavoriteAspectsData.java
+++ b/src/main/java/julianh06/wynnextras/features/aspects/FavoriteAspectsData.java
@@ -1,0 +1,194 @@
+package julianh06.wynnextras.features.aspects;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.client.MinecraftClient;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class FavoriteAspectsData {
+    public static FavoriteAspectsData INSTANCE = new FavoriteAspectsData();
+
+    public Set<String> favoriteAspects = new HashSet<>();
+    public List<String> recentSearches = new ArrayList<>();
+    private static final int MAX_RECENT_SEARCHES = 5;
+
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+    private static final Path CONFIG_PATH = FabricLoader.getInstance()
+            .getConfigDir()
+            .resolve("wynnextras/favorite_aspects.json");
+
+    public void load() {
+        if (Files.exists(CONFIG_PATH)) {
+            try (Reader reader = Files.newBufferedReader(CONFIG_PATH)) {
+                FavoriteAspectsData loaded = GSON.fromJson(reader, FavoriteAspectsData.class);
+                if (loaded != null) {
+                    if (loaded.favoriteAspects != null) {
+                        this.favoriteAspects = loaded.favoriteAspects;
+                    }
+                    if (loaded.recentSearches != null) {
+                        this.recentSearches = loaded.recentSearches;
+                    }
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        // Note: Wynntils import is done when aspect screen opens (player needs to be logged in)
+    }
+
+    private boolean wynntilsImportAttempted = false;
+
+    /**
+     * Try to import Wynntils favorites (called when aspect screen opens)
+     */
+    public void tryImportWynntils() {
+        if (wynntilsImportAttempted) return;
+        wynntilsImportAttempted = true;
+
+        int imported = importFromWynntils();
+        if (imported > 0) {
+            System.out.println("[WynnExtras] Imported " + imported + " aspect favorites from Wynntils");
+        }
+    }
+
+    public void save() {
+        try {
+            Files.createDirectories(CONFIG_PATH.getParent());
+            try (Writer writer = Files.newBufferedWriter(CONFIG_PATH)) {
+                GSON.toJson(this, writer);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public boolean isFavorite(String aspectName) {
+        return favoriteAspects.contains(aspectName);
+    }
+
+    public void toggleFavorite(String aspectName) {
+        if (favoriteAspects.contains(aspectName)) {
+            favoriteAspects.remove(aspectName);
+        } else {
+            favoriteAspects.add(aspectName);
+        }
+        save();
+    }
+
+    public List<String> getRecentSearches() {
+        return recentSearches;
+    }
+
+    public void addRecentSearch(String playerName) {
+        // Remove if already exists (to move to top)
+        recentSearches.remove(playerName);
+        // Add at the beginning
+        recentSearches.add(0, playerName);
+        // Trim to max size
+        while (recentSearches.size() > MAX_RECENT_SEARCHES) {
+            recentSearches.remove(recentSearches.size() - 1);
+        }
+        save();
+    }
+
+    // Archetype names for mythic aspect detection
+    private static final String[] ARCHETYPES = {
+        // Warrior
+        "Fallen", "Paladin", "Battle Monk",
+        // Shaman
+        "Summoner", "Ritualist", "Acolyte",
+        // Mage
+        "Riftwalker", "Light Bender", "Arcanist",
+        // Archer
+        "Boltslinger", "Sharpshooter", "Trapper",
+        // Assassin
+        "Shadestepper", "Trickster", "Acrobat"
+    };
+
+    /**
+     * Check if an item name is an aspect
+     * Regular aspects: "Aspect of ..."
+     * Mythic aspects: "{Archetype}'s Embodiment of ..."
+     */
+    private boolean isAspect(String itemName) {
+        if (itemName.startsWith("Aspect of")) {
+            return true;
+        }
+        // Check for mythic aspects (archetype embodiments)
+        for (String archetype : ARCHETYPES) {
+            if (itemName.startsWith(archetype + "'s")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Import aspect favorites from Wynntils config
+     * Wynntils stores favorites in {gameDir}/wynntils/config/{uuid}.conf.json under "itemFavoriteFeature.favoriteItems"
+     * @return number of aspects imported
+     */
+    public int importFromWynntils() {
+        MinecraftClient client = MinecraftClient.getInstance();
+        if (client == null || client.player == null) {
+            return 0;
+        }
+
+        // UUID without dashes (how Wynntils stores it)
+        String uuid = client.player.getUuidAsString().replace("-", "");
+
+        // Wynntils config is in {gameDir}/wynntils/config/, not in the config folder
+        // getConfigDir() returns {gameDir}/config, so we go up one level
+        Path gameDir = FabricLoader.getInstance().getConfigDir().getParent();
+        Path wynntilsConfig = gameDir.resolve("wynntils/config/" + uuid + ".conf.json");
+
+        System.out.println("[WynnExtras] Looking for Wynntils config at: " + wynntilsConfig);
+
+        if (!Files.exists(wynntilsConfig)) {
+            System.out.println("[WynnExtras] Wynntils config not found");
+            return 0;
+        }
+
+        int imported = 0;
+        try (Reader reader = Files.newBufferedReader(wynntilsConfig)) {
+            JsonObject root = JsonParser.parseReader(reader).getAsJsonObject();
+
+            if (root.has("itemFavoriteFeature.favoriteItems")) {
+                JsonArray favorites = root.getAsJsonArray("itemFavoriteFeature.favoriteItems");
+
+                for (JsonElement element : favorites) {
+                    String itemName = element.getAsString();
+                    // Only import aspects
+                    if (isAspect(itemName) && !favoriteAspects.contains(itemName)) {
+                        favoriteAspects.add(itemName);
+                        imported++;
+                    }
+                }
+
+                if (imported > 0) {
+                    save();
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("[WynnExtras] Failed to import Wynntils favorites: " + e.getMessage());
+        }
+
+        return imported;
+    }
+}

--- a/src/main/java/julianh06/wynnextras/features/aspects/GambitData.java
+++ b/src/main/java/julianh06/wynnextras/features/aspects/GambitData.java
@@ -1,0 +1,116 @@
+package julianh06.wynnextras.features.aspects;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Stores current day's gambits
+ * Gambits reset daily at 19:00 CET (temporarily 21:10 CET for testing)
+ */
+public class GambitData {
+    public static final GambitData INSTANCE = new GambitData();
+
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static final String CONFIG_DIR = "config/wynnextras";
+    private static final String DATA_FILE = "aspects_gambits.json";
+
+    // Reset time: 19:00 CET
+    private static final int RESET_HOUR = 19;
+    private static final int RESET_MINUTE = 0;
+
+    public long savedTimestamp = 0; // When the data was saved (epoch millis)
+    public List<GambitEntry> gambits = new ArrayList<>();
+
+    public static class GambitEntry {
+        public String name;
+        public String description;
+
+        public GambitEntry(String name, String description) {
+            this.name = name;
+            this.description = description;
+        }
+    }
+
+    /**
+     * Save gambits for today
+     */
+    public void saveGambits(List<GambitEntry> gambitList) {
+        this.savedTimestamp = System.currentTimeMillis();
+        this.gambits = new ArrayList<>(gambitList);
+        save();
+    }
+
+    /**
+     * Get the last reset time (most recent RESET_HOUR:RESET_MINUTE CET before now)
+     */
+    private long getLastResetTime() {
+        ZonedDateTime now = ZonedDateTime.now(ZoneId.of("CET"));
+        ZonedDateTime resetToday = now.withHour(RESET_HOUR).withMinute(RESET_MINUTE).withSecond(0).withNano(0);
+
+        // If we haven't reached reset time today, last reset was yesterday
+        if (now.isBefore(resetToday)) {
+            resetToday = resetToday.minusDays(1);
+        }
+
+        return resetToday.toInstant().toEpochMilli();
+    }
+
+    /**
+     * Check if we have valid gambits (saved after the last reset)
+     */
+    public boolean hasToday() {
+        if (gambits.isEmpty()) return false;
+
+        long lastReset = getLastResetTime();
+        return savedTimestamp >= lastReset;
+    }
+
+    /**
+     * Save to file
+     */
+    public void save() {
+        try {
+            File configDir = new File(CONFIG_DIR);
+            if (!configDir.exists()) {
+                configDir.mkdirs();
+            }
+
+            File file = new File(configDir, DATA_FILE);
+            try (FileWriter writer = new FileWriter(file)) {
+                GSON.toJson(this, writer);
+            }
+        } catch (Exception e) {
+            System.err.println("Failed to save gambit data: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Load from file
+     */
+    public void load() {
+        try {
+            File file = new File(CONFIG_DIR, DATA_FILE);
+            if (!file.exists()) {
+                return;
+            }
+
+            try (FileReader reader = new FileReader(file)) {
+                GambitData loaded = GSON.fromJson(reader, GambitData.class);
+                if (loaded != null) {
+                    this.savedTimestamp = loaded.savedTimestamp;
+                    this.gambits = loaded.gambits != null ? loaded.gambits : new ArrayList<>();
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("Failed to load gambit data: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/julianh06/wynnextras/features/aspects/GambitNotifier.java
+++ b/src/main/java/julianh06/wynnextras/features/aspects/GambitNotifier.java
@@ -1,0 +1,104 @@
+package julianh06.wynnextras.features.aspects;
+
+import com.wynntils.utils.mc.McUtils;
+import julianh06.wynnextras.core.WynnExtras;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.minecraft.text.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.*;
+
+/**
+ * Notifies players about gambit resets
+ * Gambits reset daily at 05:00 UTC (midnight EST/America/New_York)
+ * Wynncraft uses US Eastern time for daily resets
+ */
+public class GambitNotifier {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GambitNotifier.class);
+    private static boolean hasSent5MinuteWarning = false;
+    private static boolean hasSentResetNotification = false;
+    private static LocalDate lastResetDate = null;
+    private static int debugTickCounter = 0;
+
+    // Wynncraft reset time - 05:00 UTC = midnight EST
+    private static final int RESET_HOUR_UTC = 5;
+    private static final int RESET_MINUTE_UTC = 0;
+
+    public static void init() {
+        ClientTickEvents.END_CLIENT_TICK.register(client -> {
+            if (client.player == null) return;
+
+            // Check every 20 ticks (1 second)
+            if (client.player.age % 20 == 0) {
+                checkGambitReset();
+            }
+        });
+    }
+
+    private static void checkGambitReset() {
+        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+
+        // Calculate next reset time (05:00 UTC = midnight EST)
+        ZonedDateTime nextReset = now.withHour(RESET_HOUR_UTC).withMinute(RESET_MINUTE_UTC).withSecond(0).withNano(0);
+
+        // If we're past reset time today, next reset is tomorrow
+        if (now.isAfter(nextReset)) {
+            nextReset = nextReset.plusDays(1);
+        }
+
+        // Calculate which "gambit day" we're in (resets at 05:00 UTC)
+        // If before 05:00 UTC, we're still in "yesterday's" gambit day
+        LocalDate currentGambitDay;
+        if (now.getHour() < RESET_HOUR_UTC) {
+            currentGambitDay = now.toLocalDate().minusDays(1);
+        } else {
+            currentGambitDay = now.toLocalDate();
+        }
+
+        // Reset notifications when new gambit day starts
+        if (lastResetDate == null || !currentGambitDay.equals(lastResetDate)) {
+            LOGGER.info("New gambit day detected: {} (was {})", currentGambitDay, lastResetDate);
+            hasSent5MinuteWarning = false;
+            hasSentResetNotification = false;
+            lastResetDate = currentGambitDay;
+        }
+
+        // Calculate time until reset
+        Duration timeUntilReset = Duration.between(now, nextReset);
+        long minutesUntilReset = timeUntilReset.toMinutes();
+        long secondsUntilReset = timeUntilReset.getSeconds();
+
+        // Debug logging every 60 seconds
+        debugTickCounter++;
+        if (debugTickCounter >= 60) {
+            debugTickCounter = 0;
+            LOGGER.debug("Gambit check - UTC time: {}:{}, minutes until reset: {}",
+                    now.getHour(), now.getMinute(), minutesUntilReset);
+        }
+
+        // Send 5 minute warning (between 4:55 and 5:00 remaining)
+        if (minutesUntilReset >= 4 && minutesUntilReset <= 5 && !hasSent5MinuteWarning) {
+            hasSent5MinuteWarning = true;
+            sendGambitWarning(minutesUntilReset);
+        }
+
+        // Send reset notification (within 30 seconds of reset)
+        if (minutesUntilReset == 0 && secondsUntilReset <= 30 && !hasSentResetNotification) {
+            hasSentResetNotification = true;
+            sendGambitResetNotification();
+        }
+    }
+
+    private static void sendGambitWarning(long minutes) {
+        Text message = WynnExtras.addWynnExtrasPrefix(Text.literal("§eDaily gambits reset in §6~" + minutes + " minutes§e! Open §6/pf§e to scan new gambits."));
+        McUtils.sendMessageToClient(message);
+        LOGGER.info("Gambit warning sent - {} minutes until reset", minutes);
+    }
+
+    private static void sendGambitResetNotification() {
+        Text message = WynnExtras.addWynnExtrasPrefix(Text.literal("§aDaily gambits have reset! §7Open §6/pf§7 to scan today's gambits."));
+        McUtils.sendMessageToClient(message);
+        LOGGER.info("Gambit reset notification sent");
+    }
+}

--- a/src/main/java/julianh06/wynnextras/features/aspects/LootPoolData.java
+++ b/src/main/java/julianh06/wynnextras/features/aspects/LootPoolData.java
@@ -1,0 +1,190 @@
+package julianh06.wynnextras.features.aspects;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.time.DayOfWeek;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Stores and manages loot pool data for the 4 raids
+ * Data is saved locally in config folder
+ * Loot pools reset weekly on Friday at 19:00 CET (temporarily 21:10 CET for testing)
+ */
+public class LootPoolData {
+    public static final LootPoolData INSTANCE = new LootPoolData();
+
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static final String CONFIG_DIR = "config/wynnextras";
+    private static final String DATA_FILE = "aspects_lootpools.json";
+
+    // Reset time: Friday 19:00 CET
+    private static final int RESET_HOUR = 19;
+    private static final int RESET_MINUTE = 0;
+
+    // Map: Raid -> List of (AspectName, Rarity)
+    public Map<String, List<AspectEntry>> lootPools = new HashMap<>();
+    public long savedTimestamp = 0; // When the data was last saved (epoch millis)
+
+    private LootPoolData() {
+        // Initialize empty pools for all raids
+        lootPools.put("NOTG", new ArrayList<>());
+        lootPools.put("NOL", new ArrayList<>());
+        lootPools.put("TCC", new ArrayList<>());
+        lootPools.put("TNA", new ArrayList<>());
+    }
+
+    public static class AspectEntry {
+        public String name;
+        public String rarity; // MYTHIC, FABLED, LEGENDARY
+        public String tierInfo; // "Tier II [8/10]" or "[MAX]"
+        public String description; // What the aspect does (if available)
+
+        public AspectEntry(String name, String rarity) {
+            this.name = name;
+            this.rarity = rarity;
+            this.tierInfo = "";
+            this.description = "";
+        }
+
+        public AspectEntry(String name, String rarity, String tierInfo, String description) {
+            this.name = name;
+            this.rarity = rarity;
+            this.tierInfo = tierInfo != null ? tierInfo : "";
+            this.description = description != null ? description : "";
+        }
+    }
+
+    /**
+     * Get the last reset time (most recent Friday RESET_HOUR:RESET_MINUTE CET before now)
+     */
+    private long getLastResetTime() {
+        ZonedDateTime now = ZonedDateTime.now(ZoneId.of("CET"));
+        ZonedDateTime resetThisWeek = now.with(DayOfWeek.FRIDAY).withHour(RESET_HOUR).withMinute(RESET_MINUTE).withSecond(0).withNano(0);
+
+        // If we haven't reached reset time this Friday, or it's before Friday, last reset was last week
+        if (now.isBefore(resetThisWeek)) {
+            resetThisWeek = resetThisWeek.minusWeeks(1);
+        }
+
+        return resetThisWeek.toInstant().toEpochMilli();
+    }
+
+    /**
+     * Check if saved data is still valid (saved after last reset)
+     */
+    public boolean isDataValid() {
+        long lastReset = getLastResetTime();
+        return savedTimestamp >= lastReset;
+    }
+
+    /**
+     * Save a raid's loot pool (simple - just name and rarity)
+     */
+    public void saveLootPool(String raid, Map<String, String> aspects) {
+        List<AspectEntry> entries = new ArrayList<>();
+        for (Map.Entry<String, String> entry : aspects.entrySet()) {
+            entries.add(new AspectEntry(entry.getKey(), entry.getValue()));
+        }
+        lootPools.put(raid, entries);
+        savedTimestamp = System.currentTimeMillis();
+        save();
+    }
+
+    /**
+     * Save a raid's loot pool with full data (tier info + description)
+     */
+    public void saveLootPoolFull(String raid, List<AspectEntry> aspects) {
+        lootPools.put(raid, new ArrayList<>(aspects));
+        savedTimestamp = System.currentTimeMillis();
+        save();
+    }
+
+    /**
+     * Get a raid's loot pool
+     */
+    public List<AspectEntry> getLootPool(String raid) {
+        // Check if data is still valid (not past reset time)
+        if (!isDataValid()) {
+            // Data is stale, clear it
+            clear();
+            return new ArrayList<>();
+        }
+        return lootPools.getOrDefault(raid, new ArrayList<>());
+    }
+
+    /**
+     * Check if we have valid data for a raid
+     */
+    public boolean hasData(String raid) {
+        // Check if data is still valid (not past reset time)
+        if (!isDataValid()) {
+            return false;
+        }
+        List<AspectEntry> pool = lootPools.get(raid);
+        return pool != null && !pool.isEmpty();
+    }
+
+    /**
+     * Save to file
+     */
+    public void save() {
+        try {
+            File configDir = new File(CONFIG_DIR);
+            if (!configDir.exists()) {
+                configDir.mkdirs();
+            }
+
+            File file = new File(configDir, DATA_FILE);
+            try (FileWriter writer = new FileWriter(file)) {
+                GSON.toJson(this, writer);
+            }
+        } catch (Exception e) {
+            System.err.println("Failed to save loot pool data: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Load from file
+     */
+    public void load() {
+        try {
+            File file = new File(CONFIG_DIR, DATA_FILE);
+            if (!file.exists()) {
+                return;
+            }
+
+            try (FileReader reader = new FileReader(file)) {
+                LootPoolData loaded = GSON.fromJson(reader, LootPoolData.class);
+                if (loaded != null) {
+                    if (loaded.lootPools != null) {
+                        this.lootPools = loaded.lootPools;
+                    }
+                    this.savedTimestamp = loaded.savedTimestamp;
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("Failed to load loot pool data: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Clear all data
+     */
+    public void clear() {
+        lootPools.clear();
+        lootPools.put("NOTG", new ArrayList<>());
+        lootPools.put("NOL", new ArrayList<>());
+        lootPools.put("TCC", new ArrayList<>());
+        lootPools.put("TNA", new ArrayList<>());
+        save();
+    }
+}

--- a/src/main/java/julianh06/wynnextras/features/aspects/ScreenTitleDebugger.java
+++ b/src/main/java/julianh06/wynnextras/features/aspects/ScreenTitleDebugger.java
@@ -1,0 +1,97 @@
+package julianh06.wynnextras.features.aspects;
+
+import com.wynntils.utils.mc.McUtils;
+import julianh06.wynnextras.core.WynnExtras;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Debug utility to log screen titles for discovering menu identifiers.
+ *
+ * This class logs every unique screen title to both:
+ * - The game log (visible in logs/latest.log)
+ * - In-game chat (when debug mode is enabled)
+ *
+ * Used to discover Unicode identifiers for:
+ * - Preview chest (for loot pool crowdsourcing)
+ * - Party Finder menu (for gambit detection)
+ *
+ * Enable/disable via /we aspects debug command.
+ */
+public class ScreenTitleDebugger {
+    private static final Logger LOGGER = LoggerFactory.getLogger("WynnExtras-ScreenDebug");
+
+    private static String lastLoggedTitle = null;
+    private static boolean debugEnabled = false;
+
+    public static void register() {
+        ClientTickEvents.END_CLIENT_TICK.register(client -> {
+            if (!debugEnabled) return;
+
+            MinecraftClient mc = MinecraftClient.getInstance();
+            if (mc.player == null || mc.world == null) return;
+
+            Screen screen = mc.currentScreen;
+            if (screen == null) {
+                if (lastLoggedTitle != null) {
+                    lastLoggedTitle = null;
+                }
+                return;
+            }
+
+            String title = screen.getTitle().getString();
+            String titleHex = toHexString(title);
+
+            // Only log when title changes
+            if (!title.equals(lastLoggedTitle)) {
+                lastLoggedTitle = title;
+
+                // Log to file
+                LOGGER.info("=== SCREEN OPENED ===");
+                LOGGER.info("Title (raw): {}", title);
+                LOGGER.info("Title (hex): {}", titleHex);
+                LOGGER.info("Screen class: {}", screen.getClass().getName());
+                LOGGER.info("=====================");
+
+                // Log to chat
+                McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§e[DEBUG] Screen: §f" + title));
+                McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§e[DEBUG] Hex: §7" + titleHex));
+            }
+        });
+    }
+
+    /**
+     * Toggle debug mode on/off
+     */
+    public static void toggleDebug() {
+        debugEnabled = !debugEnabled;
+        if (debugEnabled) {
+            McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§aScreen title debugging ENABLED"));
+            McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§7Open any menu to see its title logged"));
+        } else {
+            McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§cScreen title debugging DISABLED"));
+        }
+    }
+
+    /**
+     * Check if debug is currently enabled
+     */
+    public static boolean isDebugEnabled() {
+        return debugEnabled;
+    }
+
+    /**
+     * Convert string to hex representation for comparing Unicode characters
+     */
+    private static String toHexString(String s) {
+        StringBuilder sb = new StringBuilder();
+        for (char c : s.toCharArray()) {
+            if (sb.length() > 0) sb.append(" ");
+            sb.append(String.format("\\u%04X", (int) c));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/julianh06/wynnextras/features/aspects/aspect.java
+++ b/src/main/java/julianh06/wynnextras/features/aspects/aspect.java
@@ -1,9 +1,11 @@
 package julianh06.wynnextras.features.aspects;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import com.wynntils.utils.mc.McUtils;
+import julianh06.wynnextras.core.WynnExtras;
 import julianh06.wynnextras.features.abilitytree.TreeLoader;
 import julianh06.wynnextras.features.profileviewer.WynncraftApiHandler;
-import julianh06.wynnextras.utils.TickScheduler;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
@@ -13,49 +15,116 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.tooltip.TooltipType;
 import net.minecraft.network.packet.c2s.play.ClientCommandC2SPacket;
 import net.minecraft.screen.slot.Slot;
+import net.minecraft.text.Text;
 import net.minecraft.util.Hand;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonArray;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.ingame.HandledScreen;
-import net.minecraft.screen.slot.Slot;
-import net.minecraft.text.Text;
-import java.util.*;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.ingame.HandledScreen;
-import net.minecraft.screen.slot.Slot;
-import net.minecraft.text.Text;
 import net.minecraft.util.Pair;
 
-
+import java.time.DayOfWeek;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.*;
 import java.util.HashMap;
 import java.util.List;
 
 
 public class aspect {
     //TODO: aus tree stuff zeug klauen, auf aspects page gehen, dann ausgeben aspect x:100
-    static Screen currScreen = MinecraftClient.getInstance().currentScreen;
-    static HandledScreen<?> screen = (currScreen instanceof HandledScreen) ? (HandledScreen<?>) currScreen : null;
     static int SearchedPages = 0;
     public static final Map<String, Pair<String, String>> allAspects = new HashMap<>();
+
+    // Upload throttling for preview chests (once per minute per raid, unless it's reset time)
+    private static final Map<String, Long> lastUploadTime = new HashMap<>();
+    private static final long UPLOAD_COOLDOWN_MS = 60000; // 60 seconds
+
+    // Reward chest aspect collection
+    private static final List<String> collectedRewardAspects = new ArrayList<>();
+
+    // Reward chest coordinates for raid detection
+    private static final Map<String, double[]> REWARD_CHEST_COORDS = Map.of(
+            "NOTG", new double[]{10342, 41, 3111},
+            "NOL",  new double[]{11005, 58, 2909},
+            "TCC",  new double[]{10817, 45, 3901},
+            "TNA",  new double[]{24489, 8, -23878}
+    );
 
     public static void openMenu(MinecraftClient client, PlayerEntity player){
         int currentSlot = player.getInventory().getSelectedSlot();
         player.getInventory().setSelectedSlot(7);
+
+        // Just click normally - this opens the character menu
         client.interactionManager.interactItem(player, Hand.MAIN_HAND);
+
         player.getInventory().setSelectedSlot(currentSlot);
+
+        // Set flag to click on "Ability Tree" when menu opens
+        maintracking.setNeedToClickAbilityTree(true);
         maintracking.setAspectScanreq(true);
     }
-
     public static Map<String, Pair<String, String>> AspectsInMenu() {
-        currScreen = MinecraftClient.getInstance().currentScreen;
-        screen = (currScreen instanceof HandledScreen) ? (HandledScreen<?>) currScreen : null;
+        Screen currScreen = MinecraftClient.getInstance().currentScreen;
+        HandledScreen<?> screen = (currScreen instanceof HandledScreen) ? (HandledScreen<?>) currScreen : null;
         Map<String, Pair<String, String>> result = new HashMap<>();
         if (screen == null) {
             return result;
         } else {
+            // On the first page (SearchedPages == 0), scan the 5 active aspects in center slots FIRST
+            if (SearchedPages == 0) {
+                int[] centerSlots = {4, 11, 15, 18, 26};
+                for (int slotIdx : centerSlots) {
+                    if (slotIdx >= screen.getScreenHandler().slots.size()) continue;
+                    Slot slot = screen.getScreenHandler().slots.get(slotIdx);
+                    if (!slot.hasStack()) continue;
+
+                    List<Text> tooltips = slot.getStack().getTooltip(Item.TooltipContext.DEFAULT, MinecraftClient.getInstance().player, TooltipType.BASIC);
+                    String name = null;
+                    String rarity = "";
+
+                    for (Text tooltip : tooltips) {
+                        String s = tooltip.getString().replaceAll("§.", "").trim();
+                        if (name == null && (s.contains("Aspect") || s.contains("Embodiment"))) {
+                            name = s;
+
+                            // Get rarity from color
+                            if (slot.getStack().getCustomName() != null &&
+                                slot.getStack().getCustomName().getStyle() != null &&
+                                slot.getStack().getCustomName().getStyle().getColor() != null) {
+                                String hexCode = slot.getStack().getCustomName().getStyle().getColor().getHexCode();
+                                if(hexCode.equals("#AA00AA")) rarity = "Mythic";
+                                else if(hexCode.equals("#FF5555")) rarity = "Fabled";
+                                else if(hexCode.equals("#55FFFF")) rarity = "Legendary";
+                            }
+                        }
+                    }
+
+                    String bestTierLine = null;
+                    for (Text tooltip : tooltips) {
+                        String candidate = extractBestTierLine(tooltip).trim();
+                        if (candidate.contains("Tier") &&
+                                (candidate.contains(">>>") || candidate.matches(".*\\[\\d+/\\d+\\].*") || candidate.contains("[MAX]"))) {
+                            if (bestTierLine == null || candidate.length() > bestTierLine.length()) {
+                                bestTierLine = candidate;
+                            }
+                        }
+                    }
+
+                    if (name != null && bestTierLine != null && !bestTierLine.isEmpty()) {
+                        bestTierLine = bestTierLine.replaceAll("^[^A-Za-z0-9]*", "");
+                        bestTierLine = bestTierLine.replaceAll("(\\[MAX])\\1+", "$1");
+                        result.put(name, new Pair<>(bestTierLine, rarity));
+                    }
+                }
+
+                // Add active aspects to global map immediately
+                for (Map.Entry<String, Pair<String, String>> entry : result.entrySet()) {
+                    allAspects.put(entry.getKey(), entry.getValue());
+                }
+
+                // Clear result map so we don't add these aspects twice
+                result.clear();
+
+                // Now continue to scan the regular slots on this page (don't return early)
+            }
+
             int[] slotsToRead = {36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53}; // fill slot indices
 
             int readCount = 0;
@@ -66,7 +135,7 @@ public class aspect {
                 // Stop early if we encounter empty slots before batch is full
                 if (!slot.hasStack()) {
                     // If this happens before readCount == 18, stop the batch immediately
-                    dummyfunction();
+                    dummyfunction(screen);
                     break; // Exit loop early, immediately go to next page
                 }
 
@@ -80,13 +149,18 @@ public class aspect {
                     if (name == null && (s.contains("Aspect") || s.contains("Embodiment"))) {
                         name = s;
 
-                        String hexCode = slot.getStack().getCustomName().getStyle().getColor().getHexCode();
-                        if(hexCode.equals("#AA00AA")) {
-                            rarity = "Mythic";
-                        } else if(hexCode.equals("#FF5555")) {
-                            rarity = "Fabled";
-                        }else if(hexCode.equals("#55FFFF")) {
-                            rarity = "Legendary";
+                        // Safe null checking for rarity detection
+                        if (slot.getStack().getCustomName() != null &&
+                            slot.getStack().getCustomName().getStyle() != null &&
+                            slot.getStack().getCustomName().getStyle().getColor() != null) {
+                            String hexCode = slot.getStack().getCustomName().getStyle().getColor().getHexCode();
+                            if(hexCode.equals("#AA00AA")) {
+                                rarity = "Mythic";
+                            } else if(hexCode.equals("#FF5555")) {
+                                rarity = "Fabled";
+                            }else if(hexCode.equals("#55FFFF")) {
+                                rarity = "Legendary";
+                            }
                         }
                     }
                 }
@@ -110,57 +184,27 @@ public class aspect {
 
                 readCount++;
                 if (readCount == 18) {
-                    dummyfunction();
+                    // Add current page aspects to global map BEFORE calling dummyfunction
+                    // This ensures page 6 aspects are included in the upload
+                    for (Map.Entry<String, Pair<String, String>> entry : result.entrySet()) {
+                        allAspects.put(entry.getKey(), entry.getValue());
+                    }
+                    dummyfunction(screen);
                     break; // Done with this page, no need to check further
                 }
 
             }
-            if (readCount < 18) {
-                int[] extraSlots = {4, 11, 15, 18, 26};
-                for (int extra : extraSlots) {
-                    // Make sure you don't scan an out-of-bounds slot!
-                    if (extra < screen.getScreenHandler().slots.size()) {
-                        Slot slot = screen.getScreenHandler().slots.get(extra);
-                        if (!slot.hasStack()) continue;
-                        List<Text> tooltips = slot.getStack().getTooltip(Item.TooltipContext.DEFAULT, MinecraftClient.getInstance().player, TooltipType.BASIC);
-                        String name = null, tierLine = null;
-                        String rarity = "";
-                        for (Text tooltip : tooltips) {
-                            String s = tooltip.getString().replaceAll("§.", "").trim();
-                            if (name == null && (s.contains("Aspect") || s.contains("Embodiment"))) name = s;
 
-                            String hexCode = slot.getStack().getCustomName().getStyle().getColor().getHexCode();
-                            if(hexCode.equals("#AA00AA")) {
-                                rarity = "Mythic";
-                            } else if(hexCode.equals("#FF5555")) {
-                                rarity = "Fabled";
-                            }else if(hexCode.equals("#55FFFF")) {
-                                rarity = "Legendary";
-                            }
-                        }
-                        String bestTierLine = null;
-                        for (Text tooltip : tooltips) {
-                            String candidate = extractBestTierLine(tooltip).trim();
-                            if (candidate.contains("Tier") &&
-                                    (candidate.contains(">>>") || candidate.matches(".*\\[\\d+/\\d+\\].*") || candidate.contains("[MAX]"))) {
-                                if (bestTierLine == null || candidate.length() > bestTierLine.length())
-                                    bestTierLine = candidate;
-                            }
-                        }
-                        if (name != null && bestTierLine != null && !bestTierLine.isEmpty()) {
-                            bestTierLine = bestTierLine.replaceAll("^[^A-Za-z0-9]*", "");
-                            bestTierLine = bestTierLine.replaceAll("(\\[MAX])\\1+", "$1");
-                            result.put(name, new Pair<>(bestTierLine, rarity));
-                        }
-                    }
-                }
-            }
+            // Add remaining aspects to global map (for pages with < 18 aspects)
             for (Map.Entry<String, Pair<String, String>> entry : result.entrySet()) {
                 allAspects.put(entry.getKey(), entry.getValue());
             }
 
             maintracking.setAspectScanreq(false);
-            if (readCount < 18 && McUtils.mc().currentScreen != null) {
+
+            // Don't close screen early - let the normal pagination complete
+            // Only close if we've searched all pages (0-6 = 7 pages total)
+            if (SearchedPages > 6 && McUtils.mc().currentScreen != null) {
                 McUtils.mc().currentScreen.close();
             }
             return result;
@@ -168,30 +212,35 @@ public class aspect {
     }
 
     public static void AspectsInRaidChest() {
-        currScreen = MinecraftClient.getInstance().currentScreen;
-        screen = (currScreen instanceof HandledScreen) ? (HandledScreen<?>) currScreen : null;
+        Screen currScreen = MinecraftClient.getInstance().currentScreen;
+        HandledScreen<?> screen = (currScreen instanceof HandledScreen) ? (HandledScreen<?>) currScreen : null;
         if (screen == null) return;
-
-        if(maintracking.goingBack) {
-            if(!screen.getScreenHandler().slots.get(16).getStack().isEmpty()) {
-                PrevPageRaid();
-            }
-        }
 
         int[] slotsToRead = {11,12,13,14,15};
         List<String> foundNames = new ArrayList<>();
 
         boolean samePage = true;
         for(int i = 11; i < 16; i++) {
+            int arrayIndex = i - 11; // Map slot 11-15 to array index 0-4
             Slot slot = screen.getScreenHandler().slots.get(i);
+            ItemStack cachedStack = maintracking.aspectsInChest[arrayIndex];
+
+            // If cached is null, definitely not same page
+            if (cachedStack == null) {
+                samePage = false;
+                break;
+            }
 
             if (slot.getStack().isEmpty()) {
-                if (!maintracking.aspectsInChest[i].isEmpty()) {
+                if (!cachedStack.isEmpty()) {
                     samePage = false;
                     break;
                 }
             } else {
-                if (!slot.getStack().getCustomName().equals(maintracking.aspectsInChest[i].getCustomName())) {
+                // Safe null check for customName comparison
+                Text currentName = slot.getStack().getCustomName();
+                Text cachedName = cachedStack.getCustomName();
+                if (currentName == null || cachedName == null || !currentName.equals(cachedName)) {
                     samePage = false;
                     break;
                 }
@@ -204,17 +253,11 @@ public class aspect {
 
         maintracking.aspectsInChest = new ItemStack[5];
 
-        if(maintracking.goingBack) {
-            if(screen.getScreenHandler().slots.get(10).getStack().isEmpty()) {
-                maintracking.scanDone = true;
-                maintracking.goingBack = false;
-            }
-        }
-
         for(int i = 11; i < 16; i++) {
+            int arrayIndex = i - 11; // Map slot 11-15 to array index 0-4
             Slot slot = screen.getScreenHandler().slots.get(i);
 
-            maintracking.aspectsInChest[i] = slot.getStack().copy();
+            maintracking.aspectsInChest[arrayIndex] = slot.getStack().copy();
 
             // Stop if empty
             if (!slot.hasStack()) break;
@@ -233,18 +276,86 @@ public class aspect {
             foundNames.add(name);
         }
 
-        // Print all aspects found this page, in order, with duplicates if there are any
-        if (MinecraftClient.getInstance().player != null) {
+        // Collect all aspects found this page
+        collectedRewardAspects.addAll(foundNames);
+
+        // Print found aspects to chat
+        if (MinecraftClient.getInstance().player != null && !foundNames.isEmpty()) {
             for (String aspectName : foundNames) {
-                McUtils.sendMessageToClient(Text.of("Found aspect: " + aspectName));
+                McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§7Found aspect: §e" + aspectName));
             }
         }
 
-        // If all 5 slots contained aspects, go to next page
+        // Check if there's a next page (slot 16)
         if (!screen.getScreenHandler().slots.get(16).getStack().isEmpty()) {
-            NextPageRaid();
+            System.out.println("[WynnExtras] Next page available, total collected so far: " + collectedRewardAspects.size());
+            NextPageRaid(screen);
         } else {
-            maintracking.goingBack = true;
+            // Last page - upload now
+            System.out.println("[WynnExtras] Last page reached, total aspects found: " + collectedRewardAspects.size());
+            maintracking.scanDone = true;
+
+            if (!collectedRewardAspects.isEmpty()) {
+                uploadCollectedAspects();
+            }
+        }
+    }
+
+    private static void uploadCollectedAspects() {
+        MinecraftClient mc = MinecraftClient.getInstance();
+        if (mc.player == null) return;
+
+        // Detect which raid based on player position
+        String currentRaid = detectRaidFromPosition();
+
+        if (currentRaid.equals("UNKNOWN")) {
+            System.err.println("[WynnExtras] Cannot determine raid type for aspect upload");
+            McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§cCannot detect raid type - too far from reward chest"));
+            collectedRewardAspects.clear();
+            return;
+        }
+
+        System.out.println("[WynnExtras] Uploading " + collectedRewardAspects.size() + " aspects from " + currentRaid);
+        McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§7Uploading §e" + collectedRewardAspects.size() + " §7aspect(s) from §6" + currentRaid + "§7..."));
+
+        // Upload to API
+        WynncraftApiHandler.uploadRewardedAspects(currentRaid, new ArrayList<>(collectedRewardAspects));
+
+        // Clear the collection for next raid
+        collectedRewardAspects.clear();
+    }
+
+    private static String detectRaidFromPosition() {
+        MinecraftClient mc = MinecraftClient.getInstance();
+        if (mc.player == null) return "UNKNOWN";
+
+        double px = mc.player.getX();
+        double py = mc.player.getY();
+        double pz = mc.player.getZ();
+
+        String closest = "UNKNOWN";
+        double minDist = Double.MAX_VALUE;
+
+        for (Map.Entry<String, double[]> entry : REWARD_CHEST_COORDS.entrySet()) {
+            double[] pos = entry.getValue();
+            double dist = Math.sqrt(Math.pow(px - pos[0], 2) + Math.pow(py - pos[1], 2) + Math.pow(pz - pos[2], 2));
+            if (dist < minDist) {
+                minDist = dist;
+                closest = entry.getKey();
+            }
+        }
+
+        // Sanity check: if player is too far from any known chest, return UNKNOWN
+        return minDist < 100 ? closest : "UNKNOWN";
+    }
+
+    /**
+     * Reset collected reward aspects (called when screen closes)
+     */
+    public static void resetRewardAspects() {
+        if (!collectedRewardAspects.isEmpty()) {
+            System.out.println("[WynnExtras] Clearing " + collectedRewardAspects.size() + " collected reward aspects");
+            collectedRewardAspects.clear();
         }
     }
 
@@ -271,34 +382,305 @@ public class aspect {
         return deepest.length() > out.length() ? deepest.toString() : out.toString();
     }
 
-    private static void dummyfunction() {
+    private static void dummyfunction(HandledScreen<?> screen) {
         //System.out.println("dummyfunction called after 18 slots read");
         SearchedPages++;
         TreeLoader.clickOnNameInInventory("Next Page",screen,MinecraftClient.getInstance());
-        if(SearchedPages<6){
+        if(SearchedPages<=6){
             maintracking.setNextPage(true);
+            // Show progress message matching UI page numbers (don't show for page 0 which is active aspects)
+            if(SearchedPages > 0) {
+                McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§7Scanning page " + (SearchedPages + 1) + "/7..."));
+            }
         }
         else{
             System.out.println(allAspects);
-            WynncraftApiHandler.processAspects(allAspects);
+            McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§aScanned " + allAspects.size() + " aspects! §7Uploading..."));
+            // Create a copy of the map to avoid it being cleared before async upload completes
+            Map<String, Pair<String, String>> aspectsCopy = new HashMap<>(allAspects);
+            WynncraftApiHandler.processAspects(aspectsCopy);
             resetAllAspects();
             SearchedPages = 0; //TODO
         }
     }
-    private static void NextPageRaid() {
-        System.out.println("all slots read");
+    private static void NextPageRaid(HandledScreen<?> screen) {
+        System.out.println("[WynnExtras] Clicking next page in reward chest");
         TreeLoader.clickOnNameInInventory("Next Page",screen,MinecraftClient.getInstance());
-        //das hat nichts mit dem treeloader direkt zu tun, ist nur ne util funktion
+        maintracking.NextPageRaid = true;
+        maintracking.GuiSettleTicks = 0;
     }
-    public static void PrevPageRaid() {
-        System.out.println("go back");
+    public static void PrevPageRaid(HandledScreen<?> screen) {
+        System.out.println("[WynnExtras] Clicking previous page in reward chest");
         TreeLoader.clickOnNameInInventory("Previous Page",screen,MinecraftClient.getInstance());
+        maintracking.PrevPageRaid = true;
+        maintracking.GuiSettleTicks = 0;
     }
     public static void setSearchedPages(int searchedPages) {
         SearchedPages = searchedPages;
     }
+    public static int getSearchedPages() {
+        return SearchedPages;
+    }
     public static void resetAllAspects() {
         allAspects.clear();
+    }
+
+    /**
+     * Check if it's currently loot pool reset time (Friday 19:00 CET, ±30 min window)
+     * During reset time, upload throttling is disabled
+     */
+    private static boolean isResetTime() {
+        ZonedDateTime now = ZonedDateTime.now(ZoneId.of("CET"));
+
+        // Only on Friday
+        if (now.getDayOfWeek() != DayOfWeek.FRIDAY) {
+            return false;
+        }
+
+        // Check if within 30 minutes of 19:00 (18:30 - 19:30)
+        int hour = now.getHour();
+        int minute = now.getMinute();
+
+        if (hour == 19 && minute <= 30) {
+            return true; // 19:00 - 19:30
+        }
+        if (hour == 18 && minute >= 30) {
+            return true; // 18:30 - 19:00
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if enough time has passed since last upload for this raid
+     * Returns true if upload is allowed
+     */
+    private static boolean canUpload(String raidType) {
+        // Always allow during reset time
+        if (isResetTime()) {
+            return true;
+        }
+
+        Long lastUpload = lastUploadTime.get(raidType);
+        if (lastUpload == null) {
+            return true; // Never uploaded before
+        }
+
+        long timeSinceLastUpload = System.currentTimeMillis() - lastUpload;
+        return timeSinceLastUpload >= UPLOAD_COOLDOWN_MS;
+    }
+
+    /**
+     * Detects and displays all 4 daily gambits from the Party Finder menu
+     * Gambit format: "Name Gambit" or "Name Name's Gambit"
+     * Example: "Glutton's Gambit", "Dull Blade's Gambit"
+     * Description is between "Refreshes in X hours" and "Rewards for enabling"
+     * Also saves to GambitData for the GUI
+     */
+    public static void detectGambit(HandledScreen<?> screen) {
+        if (screen == null) return;
+
+        try {
+            List<String> gambitsForChat = new ArrayList<>();
+            List<GambitData.GambitEntry> gambitsForSave = new ArrayList<>();
+
+            // Search through inventory slots for all gambit items
+            for (Slot slot : screen.getScreenHandler().slots) {
+                if (!slot.hasStack()) continue;
+
+                ItemStack stack = slot.getStack();
+                if (stack.getCustomName() == null) continue;
+
+                String itemName = stack.getCustomName().getString().replaceAll("§.", "").trim();
+
+                // Check if item name contains "Gambit"
+                if (itemName.contains("Gambit")) {
+                    // Get the tooltip for description
+                    List<Text> tooltips = stack.getTooltip(Item.TooltipContext.DEFAULT,
+                        MinecraftClient.getInstance().player, TooltipType.BASIC);
+
+                    StringBuilder description = new StringBuilder();
+                    boolean inDescriptionSection = false;
+
+                    for (Text tooltip : tooltips) {
+                        String line = tooltip.getString().replaceAll("§.", "").trim();
+
+                        // Start collecting after "Refreshes in" line
+                        if (line.contains("Refreshes in")) {
+                            inDescriptionSection = true;
+                            continue;
+                        }
+
+                        // Stop collecting at "Rewards for enabling" or "Rewards for Enabling"
+                        if (line.contains("Rewards for enabling") || line.contains("Rewards for Enabling")) {
+                            break;
+                        }
+
+                        // Collect description lines
+                        if (inDescriptionSection && !line.isEmpty()) {
+                            if (description.length() > 0) description.append(" ");
+                            description.append(line);
+                        }
+                    }
+
+                    // Only add if we have both name and description
+                    if (description.length() > 0) {
+                        gambitsForChat.add("§e" + itemName + " §7- " + description.toString());
+                        gambitsForSave.add(new GambitData.GambitEntry(itemName, description.toString()));
+                    }
+                }
+            }
+
+            // Save gambits to data storage
+            if (!gambitsForSave.isEmpty()) {
+                GambitData.INSTANCE.saveGambits(gambitsForSave);
+            }
+
+            // Upload to crowdsourcing API (don't spam chat)
+            if (!gambitsForSave.isEmpty()) {
+                WynncraftApiHandler.uploadGambits(gambitsForSave);
+            }
+
+        } catch (Exception e) {
+            McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§cError detecting gambit: " + e.getMessage()));
+        }
+    }
+
+    /**
+     * Scans the raid preview chest for aspects and detects which raid is selected
+     * Raid is detected from the screen title itself (last character changes per raid)
+     * Also extracts user's aspect tier and progress for each aspect
+     * Saves loot pool data locally for the GUI
+     */
+    public static void scanPreviewChest(HandledScreen<?> screen, String screenTitle) {
+        if (screen == null) return;
+
+        System.out.println("[WynnExtras] scanPreviewChest called with title: " + screenTitle);
+
+        try {
+            // Detect raid from the last character of the title
+            String selectedRaid = "Unknown";
+            if (screenTitle.endsWith("\uF00B")) {
+                selectedRaid = "NOTG";
+            } else if (screenTitle.endsWith("\uF00C")) {
+                selectedRaid = "NOL";
+            } else if (screenTitle.endsWith("\uF00D")) {
+                selectedRaid = "TCC";
+            } else if (screenTitle.endsWith("\uF00E")) {
+                selectedRaid = "TNA";
+            }
+
+            Map<String, Pair<String, String>> foundAspects = new HashMap<>();
+            List<LootPoolData.AspectEntry> lootPoolDataFull = new ArrayList<>(); // For saving with full data
+
+            // Collect all aspects with their progress
+            for (Slot slot : screen.getScreenHandler().slots) {
+                if (!slot.hasStack()) continue;
+
+                ItemStack stack = slot.getStack();
+                List<Text> tooltips = stack.getTooltip(Item.TooltipContext.DEFAULT,
+                    MinecraftClient.getInstance().player, TooltipType.BASIC);
+
+                String aspectName = null;
+                String tierLine = null;
+                String rarity = "";
+                StringBuilder description = new StringBuilder();
+                boolean foundName = false;
+                boolean foundTier = false;
+
+                for (Text tooltip : tooltips) {
+                    String line = tooltip.getString().replaceAll("§.", "").trim();
+
+                    // Find aspect name
+                    if (aspectName == null && (line.contains("Aspect") || line.contains("Embodiment"))) {
+                        aspectName = line;
+                        foundName = true;
+
+                        // Detect rarity from color with safe null checking
+                        if (stack.getCustomName() != null &&
+                            stack.getCustomName().getStyle() != null &&
+                            stack.getCustomName().getStyle().getColor() != null) {
+                            String hexCode = stack.getCustomName().getStyle().getColor().getHexCode();
+                            if (hexCode.equals("#AA00AA")) {
+                                rarity = "Mythic";
+                            } else if (hexCode.equals("#FF5555")) {
+                                rarity = "Fabled";
+                            } else if (hexCode.equals("#55FFFF")) {
+                                rarity = "Legendary";
+                            }
+                        }
+                        continue;
+                    }
+
+                    // Check if we've reached tier info
+                    if (foundName && (line.contains("Tier") || line.contains("[") || line.contains(">") || line.contains("Class Req:"))) {
+                        foundTier = true;
+                    }
+
+                    // Collect all description lines (between name and tier info)
+                    if (foundName && !foundTier && !line.isEmpty() &&
+                        !line.contains("Aspect") && !line.contains("Embodiment")) {
+                        if (description.length() > 0) {
+                            description.append("\n");
+                        }
+                        description.append(line);
+                    }
+                }
+
+                // Find best tier line
+                String bestTierLine = null;
+                for (Text tooltip : tooltips) {
+                    String candidate = extractBestTierLine(tooltip).trim();
+                    if (candidate.contains("Tier") &&
+                            (candidate.contains(">>>") || candidate.matches(".*\\[\\d+/\\d+\\].*") || candidate.contains("[MAX]"))) {
+                        if (bestTierLine == null || candidate.length() > bestTierLine.length()) {
+                            bestTierLine = candidate;
+                        }
+                    }
+                }
+
+                if (aspectName != null && bestTierLine != null && !bestTierLine.isEmpty()) {
+                    bestTierLine = bestTierLine.replaceAll("^[^A-Za-z0-9]*", "");
+                    bestTierLine = bestTierLine.replaceAll("(\\[MAX])\\1+", "$1");
+                    foundAspects.put(aspectName, new Pair<>(bestTierLine, rarity));
+
+                    // Save for loot pool data with full info
+                    if (!rarity.isEmpty()) {
+                        lootPoolDataFull.add(new LootPoolData.AspectEntry(aspectName, rarity, bestTierLine, description.toString()));
+                    }
+                }
+            }
+
+            // Save loot pool data to local storage with full info
+            if (!selectedRaid.equals("Unknown") && !lootPoolDataFull.isEmpty()) {
+                LootPoolData.INSTANCE.saveLootPoolFull(selectedRaid, lootPoolDataFull);
+            }
+
+            // Upload aspects (don't spam chat with list)
+            if (!foundAspects.isEmpty()) {
+                // Upload with throttling (once per minute per raid, unless reset time)
+                if (canUpload(selectedRaid)) {
+                    System.out.println("[WynnExtras] Found " + foundAspects.size() + " aspects, uploading...");
+
+                    // Upload personal aspects WITH progress (requires API key)
+                    WynncraftApiHandler.processAspects(foundAspects);
+
+                    // Also upload to crowdsourcing (loot pool WITHOUT personal progress, no API key)
+                    WynncraftApiHandler.uploadLootPool(selectedRaid, lootPoolDataFull);
+
+                    lastUploadTime.put(selectedRaid, System.currentTimeMillis());
+                } else {
+                    long timeSinceLastUpload = System.currentTimeMillis() - lastUploadTime.get(selectedRaid);
+                    long secondsRemaining = (UPLOAD_COOLDOWN_MS - timeSinceLastUpload) / 1000;
+                    System.out.println("[WynnExtras] Upload throttled for " + selectedRaid + ", wait " + secondsRemaining + "s");
+                    McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§7Upload cooldown: wait " + secondsRemaining + "s"));
+                }
+            }
+
+        } catch (Exception e) {
+            McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§cError scanning preview chest: " + e.getMessage()));
+            e.printStackTrace();
+        }
     }
 }
 

--- a/src/main/java/julianh06/wynnextras/features/aspects/maintracking.java
+++ b/src/main/java/julianh06/wynnextras/features/aspects/maintracking.java
@@ -1,16 +1,23 @@
 package julianh06.wynnextras.features.aspects;
 
+import com.mojang.brigadier.arguments.StringArgumentType;
 import com.wynntils.utils.mc.McUtils;
+import com.wynntils.utils.wynn.ContainerUtils;
 import julianh06.wynnextras.annotations.WEModule;
 import julianh06.wynnextras.core.WynnExtras;
 import julianh06.wynnextras.core.command.Command;
+import julianh06.wynnextras.core.command.SubCommand;
 import julianh06.wynnextras.features.abilitytree.TreeLoader;
 import julianh06.wynnextras.features.profileviewer.WynncraftApiHandler;
+import julianh06.wynnextras.utils.MinecraftUtils;
+import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.item.ItemStack;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.screen.slot.Slot;
 import net.minecraft.text.Text;
 
 import java.util.ArrayList;
@@ -20,14 +27,220 @@ import java.util.Map;
 
 @WEModule
 public class maintracking {
+
+    // Subcommand: /we aspects scan
+    private static SubCommand scanSubCmd = new SubCommand(
+            "scan",
+            "Manually scan your aspects from the ability tree",
+            (ctx) -> {
+                aspect.openMenu(MinecraftClient.getInstance(), MinecraftClient.getInstance().player);
+                return 1;
+            },
+            null,
+            null
+    );
+
+    // Subcommand: /we aspects debug
+    private static SubCommand debugSubCmd = new SubCommand(
+            "debug",
+            "Toggle screen title debugging (for finding menu identifiers)",
+            (ctx) -> {
+                ScreenTitleDebugger.toggleDebug();
+                return 1;
+            },
+            null,
+            null
+    );
+
+    // Subcommand: /we aspects raiddebug
+    private static SubCommand raidDebugSubCmd = new SubCommand(
+            "raiddebug",
+            "Toggle raid slot debugging (shows which slots are clicked)",
+            (ctx) -> {
+                AspectScreenSimple.toggleDebug();
+                return 1;
+            },
+            null,
+            null
+    );
+
+    // Subcommand: /we aspects lootpool
+    private static SubCommand lootpoolSubCmd = new SubCommand(
+            "lootpool",
+            "Open the loot pool page",
+            (ctx) -> {
+                MinecraftUtils.mc().send(() -> {
+                    AspectScreenSimple.openLootPool();
+                });
+                return 1;
+            },
+            null,
+            null
+    );
+
+    // Subcommand: /we aspects my (or misc as alias)
+    private static SubCommand mySubCmd = new SubCommand(
+            "my",
+            "Open your aspects page",
+            (ctx) -> {
+                MinecraftUtils.mc().send(() -> {
+                    AspectScreenSimple.openMyAspects();
+                });
+                return 1;
+            },
+            null,
+            null
+    );
+
+    private static SubCommand miscSubCmd = new SubCommand(
+            "misc",
+            "Open the gambits page",
+            (ctx) -> {
+                MinecraftUtils.mc().send(() -> {
+                    AspectScreenSimple.openGambits();
+                });
+                return 1;
+            },
+            null,
+            null
+    );
+
+    // Subcommand: /we aspects gambit
+    private static SubCommand gambitSubCmd = new SubCommand(
+            "gambit",
+            "Open the gambits page",
+            (ctx) -> {
+                MinecraftUtils.mc().send(() -> {
+                    AspectScreenSimple.openGambits();
+                });
+                return 1;
+            },
+            null,
+            null
+    );
+
+    // Subcommand: /we aspects raidloot
+    private static SubCommand raidlootSubCmd = new SubCommand(
+            "raidloot",
+            "Open the raid loot tracker page",
+            (ctx) -> {
+                MinecraftUtils.mc().send(() -> {
+                    AspectScreenSimple.openRaidLoot();
+                });
+                return 1;
+            },
+            null,
+            null
+    );
+
+    // Subcommand: /we aspects explore
+    private static SubCommand exploreSubCmd = new SubCommand(
+            "explore",
+            "Browse other players' aspects",
+            (ctx) -> {
+                MinecraftUtils.mc().send(() -> {
+                    AspectScreenSimple.openExplore();
+                });
+                return 1;
+            },
+            null,
+            null
+    );
+
+    // Subcommand: /we aspects leaderboard
+    private static SubCommand leaderboardSubCmd = new SubCommand(
+            "leaderboard",
+            "View the aspect leaderboard",
+            (ctx) -> {
+                MinecraftUtils.mc().send(() -> {
+                    AspectScreenSimple.openLeaderboard();
+                });
+                return 1;
+            },
+            null,
+            null
+    );
+
+    // Subcommand: /we aspects wipe
+    private static SubCommand wipeSubCmd = new SubCommand(
+            "wipe",
+            "Wipe your aspect data from the database (DEBUG)",
+            (ctx) -> {
+                MinecraftUtils.mc().send(() -> {
+                    McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§eWiping your aspect data..."));
+                    WynncraftApiHandler.wipePlayerAspects();
+                });
+                return 1;
+            },
+            null,
+            null
+    );
+
+    // Main command with player argument: /we aspects <player>
+    private static Command aspectsCmdWithArg = new Command(
+            "aspects",
+            "Search for a player's aspects",
+            (ctx) -> {
+                String playerName = StringArgumentType.getString(ctx, "player");
+                MinecraftUtils.mc().send(() -> {
+                    AspectScreenSimple.openPlayer(playerName);
+                });
+                return 1;
+            },
+            List.of(scanSubCmd, debugSubCmd, raidDebugSubCmd, lootpoolSubCmd, mySubCmd, miscSubCmd,
+                    gambitSubCmd, raidlootSubCmd, exploreSubCmd, leaderboardSubCmd, wipeSubCmd),
+            List.of(ClientCommandManager.argument("player", StringArgumentType.word()))
+    );
+
+    // Main command without arguments: /we aspects
+    private static Command aspectsCmd = new Command(
+            "aspects",
+            "Aspect tracking and management",
+            (ctx) -> {
+                // Default: open aspects screen (My Aspects page)
+                MinecraftUtils.mc().send(() -> {
+                    AspectScreenSimple.openMyAspects();
+                });
+                return 1;
+            },
+            List.of(scanSubCmd, debugSubCmd, raidDebugSubCmd, lootpoolSubCmd, mySubCmd, miscSubCmd,
+                    gambitSubCmd, raidlootSubCmd, exploreSubCmd, leaderboardSubCmd, wipeSubCmd),
+            null
+    );
+
+    // Command: /we gambits
+    private static Command gambitsCmd = new Command(
+            "gambits",
+            "View today's gambits and countdown",
+            (ctx) -> {
+                MinecraftUtils.mc().send(() -> {
+                    AspectScreenSimple.openGambits();
+                });
+                return 1;
+            },
+            null,
+            null
+    );
+
+    // Command: /we lootpool
+    private static Command lootpoolCmd = new Command(
+            "lootpool",
+            "View raid loot pools",
+            (ctx) -> {
+                MinecraftUtils.mc().send(() -> {
+                    AspectScreenSimple.openLootPool();
+                });
+                return 1;
+            },
+            null,
+            null
+    );
+
+    // Legacy command for backwards compatibility
     private static Command Scanaspects = new Command(
             "ScanAspects",
-            "Command to manually scan your Aspects",
+            "Command to manually scan your Aspects (legacy, use /we aspects scan)",
             (ctx)->{
-                if(WynncraftApiHandler.INSTANCE.API_KEY == null) {
-                    McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§bYou need to set your api-key to use this feature.Run \"/we apikey\" for more information."));
-                    return 0;
-                }
                 aspect.openMenu(MinecraftClient.getInstance(),MinecraftClient.getInstance().player);
                 return 0;
             },
@@ -37,35 +250,54 @@ public class maintracking {
 
     //TODO: interfaces tracken und dann zeug aufrufen
     static boolean inTreeMenu = false;
-    static boolean inCompassMenu = false;
     static boolean AspectScanreq = false;
     static boolean inAspectMenu = false;
     static boolean nextPage = false;
     static boolean inRaidChest = false;
+    static boolean inPartyFinder = false;
+    static boolean inPreviewChest = false;
     static boolean Raiddone = true;
     static boolean PrevPageRaid = false;
     static int GuiSettleTicks = 0;
     static int counter = 0;
     static boolean NextPageRaid = false;
-    static Screen currScreen = MinecraftClient.getInstance().currentScreen;
-    static HandledScreen<?> screen = (currScreen instanceof HandledScreen) ? (HandledScreen<?>) currScreen : null;
     public static ItemStack[] aspectsInChest = new ItemStack[5];
     public static Boolean scanDone = false;
     public static Boolean goingBack = false;
+    static boolean gambitDetected = false;
+    static String lastPreviewChestTitle = "";
+    static boolean needToClickAbilityTree = false;
+    static boolean inCharacterMenu = false;
+    static int characterMenuWaitTicks = 0;
 
     public static void init(){
+        // Load saved loot pool data
+        LootPoolData.INSTANCE.load();
+        GambitData.INSTANCE.load();
+        FavoriteAspectsData.INSTANCE.load();
+
+        // Register the screen title debugger
+        ScreenTitleDebugger.register();
+
+        // Initialize gambit reset notifications
+        GambitNotifier.init();
+
         ClientTickEvents.END_CLIENT_TICK.register((tick) -> {
             MinecraftClient client = MinecraftClient.getInstance();
             if (client.player == null || client.world == null) {
                 return;
             }
-
             Screen currScreen = client.currentScreen;
+            HandledScreen<?> screen = null;
             if (currScreen == null) {
                 scanDone = false;
                 goingBack = false;
                 nextPage = false;
                 aspectsInChest = new ItemStack[5];
+                gambitDetected = false;
+                lastPreviewChestTitle = "";
+                aspect.resetRewardAspects();
+                // DON'T reset needToClickAbilityTree - it needs to persist across screen changes
                 return;
             }
 
@@ -73,27 +305,63 @@ public class maintracking {
             else screen = null;
 
             String InventoryTitle = currScreen.getTitle().getString();
+
             inTreeMenu = InventoryTitle.equals("\uDAFF\uDFEA\uE000");
-            inCompassMenu = InventoryTitle.equals("\uDAFF\uDFDC\uE003");
             inAspectMenu = InventoryTitle.equals("\uDAFF\uDFEA\uE002");
             inRaidChest = InventoryTitle.equals("\uDAFF\uDFEA\uE00E");
+            inPartyFinder = InventoryTitle.equals("\uDAFF\uDFE1\uE00C");
+            // Character menu (opened with right-click on slot 7 without sneaking)
+            inCharacterMenu = InventoryTitle.equals("\uDAFF\uDFDC\uE003");
 
-            if(inCompassMenu && AspectScanreq) {
-                TreeLoader.clickOnNameInInventory("Ability Tree", screen, MinecraftClient.getInstance());
-                aspect.setSearchedPages(0);
+            // Preview chests have different titles for each raid
+            inPreviewChest = InventoryTitle.equals("\uDAFF\uDFEA\uE00D\uDAFF\uDF6F\uF00B") || // NOTG
+                             InventoryTitle.equals("\uDAFF\uDFEA\uE00D\uDAFF\uDF6F\uF00C") || // NOL
+                             InventoryTitle.equals("\uDAFF\uDFEA\uE00D\uDAFF\uDF6F\uF00D") || // TCC
+                             InventoryTitle.equals("\uDAFF\uDFEA\uE00D\uDAFF\uDF6F\uF00E");   // TNA
+
+            // Character menu: wait 5 ticks then click slot 9 (Ability Tree) to open the tree menu
+            if(inCharacterMenu && needToClickAbilityTree){
+                ScreenHandler menu = McUtils.containerMenu();
+                if(menu == null) return;
+
+                characterMenuWaitTicks++;
+                if(characterMenuWaitTicks >= 5){
+                    if(menu.slots.size() > 9) {
+                        Slot slot = menu.getSlot(9);
+                        if(slot != null && slot.getStack() != null && slot.getStack().getName() != null) {
+                            String name = slot.getStack().getName().getString();
+                            if(name.contains("Ability Tree")) {
+                                ContainerUtils.clickOnSlot(9, menu.syncId, 0, menu.getStacks());
+                                needToClickAbilityTree = false;
+                                characterMenuWaitTicks = 0;
+                            }
+                        }
+                    }
+                }
                 return;
             }
+
             if(inTreeMenu && AspectScanreq){
+                needToClickAbilityTree = false; // Reset flag since we're now in the tree menu
                 TreeLoader.clickOnNameInInventory("Aspects", screen, MinecraftClient.getInstance());
                 aspect.setSearchedPages(0);
+                GuiSettleTicks = 0; // Reset settle ticks for fresh start
                 return;
             }
             if(inAspectMenu && AspectScanreq){
-                aspect.AspectsInMenu();
+                // Add delay when first entering aspect menu to ensure everything loads
+                if(GuiSettleTicks > 5){
+                    GuiSettleTicks = 0;
+                    aspect.AspectsInMenu();
+                } else {
+                    GuiSettleTicks++;
+                }
                 return;
             }
             if(inAspectMenu && nextPage){
-                if(GuiSettleTicks>7){
+                // Use longer delay for first 3 pages to ensure all aspects are loaded
+                int requiredTicks = (aspect.getSearchedPages() <= 3) ? 6 : 4;
+                if(GuiSettleTicks > requiredTicks){
                     nextPage=false;
                     GuiSettleTicks=0;
                     aspect.AspectsInMenu();
@@ -105,45 +373,45 @@ public class maintracking {
                 }
             }
 
-//            if(inRaidChest && !scanDone){
-//                try {
-//                    aspect.AspectsInRaidChest();
-//                } catch (Exception e) {
-//                    McUtils.sendMessageToClient(Text.of("crash"));
-//                }
-//                return;
-//            }
+            if(inPartyFinder && !gambitDetected){
+                gambitDetected = true;
+                aspect.detectGambit(screen);
+                return;
+            }
 
-//            if(inRaidChest && Raiddone){
-//                Raiddone = false;
-//                aspect.AspectsInRaidChest();
-//                return;
-//            }
-//            if(inRaidChest && NextPageRaid){
-//                if(GuiSettleTicks>7){
-//                    NextPageRaid=false;
-//                    GuiSettleTicks=0;
-//                    aspect.AspectsInRaidChest();
-//                    return;
-//                } else{
-//                    GuiSettleTicks++;
-//                    return;
-//                }
-//            }
-//            if(inRaidChest && PrevPageRaid){
-//                if(GuiSettleTicks>7){
-//                    if(counter == 4) {
-//                        PrevPageRaid = false;
-//                        GuiSettleTicks = 0;
-//                        counter = 0;
-//                    }
-//                    aspect.PrevPageRaid();
-//                    counter++;
-//                }
-//                else{
-//                    GuiSettleTicks++;
-//                }
-//            }
+            // Preview chest: scan when title changes (allows switching raids inside the chest)
+            if(inPreviewChest){
+                String currentTitle = currScreen.getTitle().getString();
+                if(!currentTitle.equals(lastPreviewChestTitle)){
+                    System.out.println("[WynnExtras] Preview chest detected, title: " + currentTitle);
+                    lastPreviewChestTitle = currentTitle;
+                    aspect.scanPreviewChest(screen, currentTitle);
+                }
+                return;
+            }
+
+            // Reward chest: scan aspects from slots 11-15 and upload
+            if(inRaidChest && !scanDone){
+                try {
+                    aspect.AspectsInRaidChest();
+                } catch (Exception e) {
+                    System.err.println("[WynnExtras] Error scanning raid chest: " + e.getMessage());
+                    e.printStackTrace();
+                }
+                return;
+            }
+
+            if(inRaidChest && NextPageRaid){
+                if(GuiSettleTicks>7){
+                    NextPageRaid=false;
+                    GuiSettleTicks=0;
+                    aspect.AspectsInRaidChest();
+                    return;
+                } else{
+                    GuiSettleTicks++;
+                    return;
+                }
+            }
         });
     }
     public static boolean getinTreeMenu(){
@@ -163,5 +431,8 @@ public class maintracking {
     }
     public static void setPrevPageRaid(boolean nextPage) {
         maintracking.PrevPageRaid = nextPage;
+    }
+    public static void setNeedToClickAbilityTree(boolean value) {
+        needToClickAbilityTree = value;
     }
 }

--- a/src/main/java/julianh06/wynnextras/features/profileviewer/WynncraftApiHandler.java
+++ b/src/main/java/julianh06/wynnextras/features/profileviewer/WynncraftApiHandler.java
@@ -3,6 +3,7 @@ package julianh06.wynnextras.features.profileviewer;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.reflect.TypeToken;
@@ -34,8 +35,10 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -45,8 +48,14 @@ import java.util.stream.Collectors;
 public class WynncraftApiHandler {
     public static WynncraftApiHandler INSTANCE = new WynncraftApiHandler();
 
-    public List<ApiAspect> aspectList = new ArrayList<>();
+    // Reuse HttpClient instance instead of creating new ones
+    private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+
+    // Use synchronized list to prevent concurrent modification
+    public List<ApiAspect> aspectList = java.util.Collections.synchronizedList(new ArrayList<>());
     public boolean[] waitingForAspectResponse = new boolean[5];
+    // Lock object for synchronizing array access
+    private final Object aspectLock = new Object();
 
     private static Command apiKeyCmd = new Command(
             "apikey",
@@ -86,13 +95,12 @@ public class WynncraftApiHandler {
     public String API_KEY;
 
     public static CompletableFuture<String> fetchUUID(String playerName) {
-        HttpClient client = HttpClient.newHttpClient();
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create("https://api.mojang.com/users/profiles/minecraft/" + playerName))
                 .GET()
                 .build();
 
-        return client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+        return HTTP_CLIENT.sendAsync(request, HttpResponse.BodyHandlers.ofString())
                 .thenApply(HttpResponse::body)
                 .thenApply(body -> {
                     try {
@@ -112,7 +120,6 @@ public class WynncraftApiHandler {
     }
 
     public static CompletableFuture<GuildData> fetchGuildData(String prefix) {
-        HttpClient client = HttpClient.newHttpClient();
         HttpRequest request;
 
         if (INSTANCE.API_KEY == null) {
@@ -132,18 +139,17 @@ public class WynncraftApiHandler {
                     .build();
         }
 
-        return client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+        return HTTP_CLIENT.sendAsync(request, HttpResponse.BodyHandlers.ofString())
                 .thenApply(HttpResponse::body)
                 .thenApply(WynncraftApiHandler::parseGuildData);
     }
 
     public static CompletableFuture<List<ApiAspect>> fetchAspectList(String className) {
-        HttpClient client = HttpClient.newHttpClient();
         HttpRequest request;
 
         if(INSTANCE.API_KEY == null) {
-            McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("You need to set you api-key to upload your aspects. For more info run \"/WynnExtras apikey\""));
-            return null;
+            McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("You need to set your api-key to upload your aspects. For more info run \"/WynnExtras apikey\""));
+            return CompletableFuture.completedFuture(null);
         } else {
             request = HttpRequest.newBuilder()
                     .uri(URI.create("https://api.wynncraft.com/v3/aspects/" + className))
@@ -152,7 +158,7 @@ public class WynncraftApiHandler {
                     .build();
         }
 
-        return client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+        return HTTP_CLIENT.sendAsync(request, HttpResponse.BodyHandlers.ofString())
                 .thenApply(HttpResponse::body)
                 .thenApply(WynncraftApiHandler::parseAspectData);
     }
@@ -161,29 +167,73 @@ public class WynncraftApiHandler {
         List<String> classes = List.of("warrior", "shaman", "mage", "archer", "assassin");
         List<ApiAspect> aspectList = WynncraftApiHandler.INSTANCE.aspectList;
 
-        if(!aspectList.isEmpty()) return aspectList;
+        if(!aspectList.isEmpty()) {
+            return aspectList;
+        }
 
+        // Check API key before attempting fetch
+        if (INSTANCE.API_KEY == null) {
+            return aspectList; // Return empty list, message already shown by fetchAspectList
+        }
 
-        int i = 0;
-        for(String className : classes) {
-            if(WynncraftApiHandler.INSTANCE.waitingForAspectResponse[i]) continue;
+        // Synchronize access to waitingForAspectResponse array
+        synchronized (INSTANCE.aspectLock) {
+            // Check if ALL classes are marked as waiting but list is still empty - means previous fetch failed
+            boolean allWaiting = true;
+            for (int j = 0; j < 5; j++) {
+                if (!WynncraftApiHandler.INSTANCE.waitingForAspectResponse[j]) {
+                    allWaiting = false;
+                    break;
+                }
+            }
+            if (allWaiting && aspectList.isEmpty()) {
+                // Reset all flags - previous fetch must have failed
+                for (int j = 0; j < 5; j++) {
+                    WynncraftApiHandler.INSTANCE.waitingForAspectResponse[j] = false;
+                }
+            }
 
-            WynncraftApiHandler.INSTANCE.waitingForAspectResponse[i] = true;
+            int i = 0;
+            for(String className : classes) {
+                if(WynncraftApiHandler.INSTANCE.waitingForAspectResponse[i]) {
+                    i++;
+                    continue;
+                }
 
-            int finalI = i;
-            WynncraftApiHandler.fetchAspectList(className)
-                    .thenAccept(result -> {
-                        if(result == null) return;
-                        if(result.isEmpty()) return;
+                WynncraftApiHandler.INSTANCE.waitingForAspectResponse[i] = true;
 
-                        WynncraftApiHandler.INSTANCE.waitingForAspectResponse[finalI] = false;
-                        aspectList.addAll(result);
-                    })
-                    .exceptionally(ex -> {
-                        System.err.println("Unexpected error: " + ex.getMessage());
-                        return null;
-                    });
-            i++;
+                int finalI = i;
+                CompletableFuture<List<ApiAspect>> future = WynncraftApiHandler.fetchAspectList(className);
+                if (future != null) {
+                    future.thenAccept(result -> {
+                                if(result == null) return;
+                                if(result.isEmpty()) return;
+
+                                synchronized (INSTANCE.aspectLock) {
+                                    WynncraftApiHandler.INSTANCE.waitingForAspectResponse[finalI] = false;
+                                }
+                                // Only add aspects that aren't already in the list (prevent duplicates)
+                                // aspectList is already synchronized, but we need to check-then-add atomically
+                                synchronized (aspectList) {
+                                    for (ApiAspect aspect : result) {
+                                        boolean alreadyExists = aspectList.stream()
+                                            .anyMatch(existing -> existing.getName().equals(aspect.getName()));
+                                        if (!alreadyExists) {
+                                            aspectList.add(aspect);
+                                        }
+                                    }
+                                }
+                            })
+                            .exceptionally(ex -> {
+                                System.err.println("Unexpected error fetching aspects: " + ex.getMessage());
+                                synchronized (INSTANCE.aspectLock) {
+                                    WynncraftApiHandler.INSTANCE.waitingForAspectResponse[finalI] = false;
+                                }
+                                return null;
+                            });
+                }
+                i++;
+            }
         }
 
         return aspectList;
@@ -197,7 +247,6 @@ public class WynncraftApiHandler {
             }
 
             String formattedUUID = formatUUID(rawUUID);
-            HttpClient client = HttpClient.newHttpClient();
             HttpRequest request;
 
             if (INSTANCE.API_KEY == null) {
@@ -217,7 +266,7 @@ public class WynncraftApiHandler {
                         .build();
             }
 
-            return client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+            return HTTP_CLIENT.sendAsync(request, HttpResponse.BodyHandlers.ofString())
                     .thenApply(HttpResponse::body)
                     .thenApply(WynncraftApiHandler::parsePlayerData);
         });
@@ -229,10 +278,7 @@ public class WynncraftApiHandler {
             return CompletableFuture.completedFuture(null);
         }
 
-        if(INSTANCE.API_KEY == null) {
-            McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("You need to set you api-key to upload your aspects. For more info run \"/we apikey\""));
-            return CompletableFuture.completedFuture(new FetchResult(FetchStatus.NOKEYSET, null));
-        }
+        // No API key required - viewing aspects is public!
 
         try {
             HttpClient client = HttpClient.newBuilder()
@@ -240,10 +286,7 @@ public class WynncraftApiHandler {
                     .build();
 
             HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create("http://wynnextras.com/user"))
-                    .header("playerUUID", playerUUID)
-                    .header("Wynncraft-Api-Key", INSTANCE.API_KEY)
-                    .header("RequestingUUID", requestingUUID)
+                    .uri(URI.create("http://wynnextras.com/aspects?playerUuid=" + playerUUID))
                     .timeout(Duration.ofSeconds(8))
                     .GET()
                     .build();
@@ -267,14 +310,17 @@ public class WynncraftApiHandler {
                         }
 
                         if (code == 400) {
+                            System.err.println("GET ERROR 400: " + response.body());
                             return new FetchResult(FetchStatus.UNKNOWN_ERROR, null);
                         }
 
                         if (code >= 500) {
+                            System.err.println("GET SERVER ERROR: " + code + " → " + response.body());
                             return new FetchResult(FetchStatus.SERVER_ERROR, null);
                         }
 
                         if (code != 200) {
+                            System.err.println("GET ERROR: " + code + " → " + response.body());
                             return new FetchResult(FetchStatus.UNKNOWN_ERROR, null);
                         }
 
@@ -289,39 +335,98 @@ public class WynncraftApiHandler {
     }
 
     public static void processAspects(Map<String, Pair<String, String>> map) {
-        if(INSTANCE.API_KEY == null) {
-            McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("You need to set you api-key to upload your aspects. For more info run \"/WynnExtras apikey\""));
+        if (McUtils.player() == null) {
+            System.err.println("Cannot upload aspects - player not loaded");
             return;
         }
 
-        List<Aspect> aspects = new ArrayList<>();
-        for(String entry : map.keySet()) {
-            int amount = parseAspectAmount(map.get(entry));
-            Aspect aspect = new Aspect();
-            aspect.setAmount(amount);
-            aspect.setName(entry);
-            aspect.setRarity(map.get(entry).getRight());
-            aspects.add(aspect);
-        }
+        System.out.println("DEBUG: processAspects called with " + map.size() + " aspects");
 
-        User user = new User();
-        user.setUuid(McUtils.player().getUuidAsString());
-        user.setPlayerName(McUtils.playerName());
-        user.setAspects(aspects);
-        user.setModVersion(CurrentVersionData.INSTANCE.version);
-        user.setUpdatedAt(Time.now().timestamp());
+        // Authenticate with Mojang first
+        julianh06.wynnextras.utils.MojangAuth.getAuthData().thenAccept(authData -> {
+            if (authData == null) {
+                System.err.println("Failed to authenticate with Mojang for aspect upload");
+                // Don't show duplicate error - MojangAuth already showed the error
+                return;
+            }
 
-        postPlayerAspectData(user).thenAccept(result -> {
-            if (result.status() == FetchStatus.OK) {
-                McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§aSuccessfully uploaded your aspects!"));
-            } else if (result.status == FetchStatus.NOKEYSET) {
-                McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§You need to set your api-key to use this feature. Run \"/we apikey\" for more information."));
-            } else if (result.status == FetchStatus.FORBIDDEN) {
-                McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§4You need to upload your own aspects first to view other peoples aspects. Run \"/we apikey\" for more information."));
-            } else if (result.status == FetchStatus.UNAUTHORIZED) {
-                McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§4The api-key you have set is not connected to your minecraft account. Run \"/we apikey\" for more information."));
-            } else {
-                McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§4Error: " + result.status()));
+            try {
+                // Build JSON payload
+                JsonObject payload = new JsonObject();
+                payload.addProperty("playerName", authData.username);
+                payload.addProperty("modVersion", CurrentVersionData.INSTANCE.version);
+
+                JsonArray aspectsArray = new JsonArray();
+                int processedCount = 0;
+                int skippedCount = 0;
+                for (String entry : map.keySet()) {
+                    try {
+                        Pair<String, String> aspectData = map.get(entry);
+                        if (aspectData == null) {
+                            System.err.println("DEBUG: Null aspect data for: " + entry);
+                            skippedCount++;
+                            continue;
+                        }
+
+                        int amount = parseAspectAmount(aspectData);
+                        JsonObject aspectJson = new JsonObject();
+                        aspectJson.addProperty("name", entry);
+                        aspectJson.addProperty("rarity", aspectData.getRight());
+                        aspectJson.addProperty("amount", amount);
+                        aspectsArray.add(aspectJson);
+                        processedCount++;
+                    } catch (Exception e) {
+                        System.err.println("DEBUG: Error processing aspect " + entry + ": " + e.getMessage());
+                        e.printStackTrace();
+                        skippedCount++;
+                    }
+                }
+                payload.add("aspects", aspectsArray);
+
+                System.out.println("DEBUG: Loop stats - Processed: " + processedCount + ", Skipped: " + skippedCount + ", Total map size: " + map.size());
+
+                System.out.println("DEBUG: Built payload with " + aspectsArray.size() + " aspects");
+                String payloadString = payload.toString();
+                System.out.println("DEBUG: Payload size: " + payloadString.length() + " characters");
+                System.out.println("DEBUG: First 500 chars of payload: " + payloadString.substring(0, Math.min(500, payloadString.length())));
+
+                HttpClient client = HttpClient.newBuilder()
+                        .connectTimeout(Duration.ofSeconds(5))
+                        .build();
+
+                HttpRequest request = HttpRequest.newBuilder()
+                        .uri(URI.create("http://wynnextras.com/aspects"))
+                        .header("Content-Type", "application/json")
+                        .header("Username", authData.username)
+                        .header("Server-ID", authData.serverId)
+                        .POST(HttpRequest.BodyPublishers.ofString(payload.toString()))
+                        .timeout(Duration.ofSeconds(8))
+                        .build();
+
+                client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                        .thenAccept(response -> {
+                            int code = response.statusCode();
+                            if (code == 200) {
+                                McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§aSuccessfully uploaded your aspects!"));
+                            } else if (code == 401) {
+                                McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§cAuthentication failed"));
+                                System.err.println("Personal aspects upload auth error: " + response.body());
+                            } else if (code >= 500) {
+                                McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§cServer error - try again later"));
+                                System.err.println("Personal aspects upload error: " + code + " → " + response.body());
+                            } else {
+                                McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§cUpload failed (error " + code + ")"));
+                                System.err.println("Personal aspects upload error: " + code + " → " + response.body());
+                            }
+                        })
+                        .exceptionally(ex -> {
+                            McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§cUpload failed - check your connection"));
+                            System.err.println("Failed to upload personal aspects: " + ex.getMessage());
+                            return null;
+                        });
+
+            } catch (Exception e) {
+                e.printStackTrace();
             }
         });
     }
@@ -340,7 +445,7 @@ public class WynncraftApiHandler {
                     .build();
 
             HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create("http://wynnextras.com/user"))
+                    .uri(URI.create("http://wynnextras.com/aspects"))
                     .header("Content-Type", "application/json")
                     .header("Wynncraft-Api-Key", INSTANCE.API_KEY)
                     .POST(HttpRequest.BodyPublishers.ofString(json))
@@ -366,6 +471,8 @@ public class WynncraftApiHandler {
                         }
 
                         if (code >= 500) {
+                            System.err.println("SERVER ERROR: " + code + " → " + response.body());
+                            McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§cServer error (" + code + "): " + response.body()));
                             return new FetchResult(FetchStatus.SERVER_ERROR, null);
                         }
 
@@ -429,11 +536,516 @@ public class WynncraftApiHandler {
         return sum;
     }
 
+    /**
+     * Upload rewarded aspects from raid chest to API
+     * @param raidType NOTG, NOL, TCC, TNA
+     * @param aspectNames List of aspect names received from reward chest
+     */
+    public static void uploadRewardedAspects(String raidType, List<String> aspectNames) {
+        if (McUtils.player() == null) {
+            System.err.println("Cannot upload rewarded aspects - player not loaded");
+            return;
+        }
 
+        // Validate raid type
+        if (!raidType.equals("NOTG") && !raidType.equals("NOL") &&
+            !raidType.equals("TCC") && !raidType.equals("TNA")) {
+            System.err.println("Unknown raid type: " + raidType);
+            return;
+        }
+
+        if (aspectNames == null || aspectNames.isEmpty()) {
+            System.out.println("No aspects to upload");
+            return;
+        }
+
+        // Authenticate with Mojang first
+        julianh06.wynnextras.utils.MojangAuth.getAuthData().thenAccept(authData -> {
+            if (authData == null) {
+                System.err.println("Failed to authenticate with Mojang");
+                return;
+            }
+
+            try {
+                // Build JSON payload
+                JsonObject payload = new JsonObject();
+                payload.addProperty("raidType", raidType);
+
+                JsonArray aspectsArray = new JsonArray();
+                for (String aspectName : aspectNames) {
+                    aspectsArray.add(aspectName);
+                }
+                payload.add("aspects", aspectsArray);
+
+                HttpClient client = HttpClient.newBuilder()
+                        .connectTimeout(Duration.ofSeconds(5))
+                        .build();
+
+                HttpRequest request = HttpRequest.newBuilder()
+                        .uri(URI.create("http://wynnextras.com/raid/rewarded-aspects"))
+                        .header("Content-Type", "application/json")
+                        .header("Username", authData.username)
+                        .header("Server-ID", authData.serverId)
+                        .POST(HttpRequest.BodyPublishers.ofString(payload.toString()))
+                        .timeout(Duration.ofSeconds(8))
+                        .build();
+
+                client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                        .thenAccept(response -> {
+                            int code = response.statusCode();
+                            if (code == 200) {
+                                McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§aUploaded " + aspectNames.size() + " aspect(s) from §e" + raidType));
+                                System.out.println("[WynnExtras] Successfully uploaded rewarded aspects for " + raidType);
+                            } else if (code == 401) {
+                                McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§cAuthentication failed"));
+                            } else {
+                                System.err.println("Error uploading rewarded aspects: " + code);
+                            }
+                        })
+                        .exceptionally(ex -> {
+                            System.err.println("Failed to upload rewarded aspects: " + ex.getMessage());
+                            return null;
+                        });
+
+            } catch (Exception e) {
+                e.printStackTrace();
+                System.err.println("Error preparing rewarded aspects upload");
+            }
+        });
+    }
+
+    /**
+     * Wipe all aspect data for the current player from the database (DEBUG)
+     * Works by uploading an empty aspects list, which overwrites existing data
+     */
+    public static void wipePlayerAspects() {
+        if (McUtils.player() == null) {
+            System.err.println("Cannot wipe aspects - player not loaded");
+            return;
+        }
+
+        System.out.println("[WynnExtras] wipePlayerAspects() called - uploading empty aspects list");
+
+        // Just upload an empty map - this will overwrite all existing aspects with nothing
+        processAspects(new java.util.HashMap<>());
+        McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§eWiping aspects by uploading empty data..."));
+    }
+
+    /**
+     * Upload loot pool to crowdsourcing API (without personal progress)
+     * NO API KEY REQUIRED - uses player UUID from authenticated Minecraft session
+     * @param raidType NOTG, NOL, TCC, TNA
+     * @param aspects List of aspects with name, rarity (no amount/tier)
+     */
+    public static void uploadLootPool(String raidType, List<julianh06.wynnextras.features.aspects.LootPoolData.AspectEntry> aspects) {
+        if (McUtils.player() == null) {
+            System.err.println("Cannot upload loot pool - player not loaded");
+            return;
+        }
+
+        // Validate raid type (short codes only)
+        if (!raidType.equals("NOTG") && !raidType.equals("NOL") &&
+            !raidType.equals("TCC") && !raidType.equals("TNA")) {
+            System.err.println("Unknown raid type: " + raidType);
+            return;
+        }
+
+        // Authenticate with Mojang first
+        julianh06.wynnextras.utils.MojangAuth.getAuthData().thenAccept(authData -> {
+            if (authData == null) {
+                System.err.println("Failed to authenticate with Mojang");
+                return;
+            }
+
+            try {
+                // Build JSON payload matching backend spec (send short codes)
+                JsonObject payload = new JsonObject();
+                payload.addProperty("raidType", raidType);
+
+                JsonArray aspectsArray = new JsonArray();
+                for (julianh06.wynnextras.features.aspects.LootPoolData.AspectEntry aspect : aspects) {
+                    JsonObject aspectJson = new JsonObject();
+                    aspectJson.addProperty("name", aspect.name);
+                    aspectJson.addProperty("rarity", aspect.rarity);
+                    // Don't include requiredClass - backend doesn't expect it
+                    aspectsArray.add(aspectJson);
+                }
+
+                payload.add("aspects", aspectsArray);
+
+                HttpClient client = HttpClient.newBuilder()
+                        .connectTimeout(Duration.ofSeconds(5))
+                        .build();
+
+                HttpRequest request = HttpRequest.newBuilder()
+                        .uri(URI.create("http://wynnextras.com/raid/loot-pool"))
+                        .header("Content-Type", "application/json")
+                        .header("Username", authData.username)
+                        .header("Server-ID", authData.serverId)
+                        .POST(HttpRequest.BodyPublishers.ofString(payload.toString()))
+                        .timeout(Duration.ofSeconds(8))
+                        .build();
+
+                client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                        .thenAccept(response -> {
+                            int code = response.statusCode();
+                            if (code == 200) {
+                                JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject();
+                                String status = result.get("status").getAsString();
+
+                                if (status.equals("approved")) {
+                                    McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§aLoot pool for §e" + raidType + " §aapproved!"));
+                                } else {
+                                    McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§7Loot pool submitted. Waiting for more confirmations."));
+                                }
+                            } else if (code == 401) {
+                                McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§cAuthentication failed"));
+                            } else {
+                                McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§cError uploading loot pool: " + code));
+                            }
+                        })
+                        .exceptionally(ex -> {
+                            System.err.println("Failed to upload loot pool: " + ex.getMessage());
+                            return null;
+                        });
+
+            } catch (Exception e) {
+                e.printStackTrace();
+                McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§cError preparing loot pool upload"));
+            }
+        });
+    }
+
+    /**
+     * Upload gambits to crowdsourcing API
+     * Uses Mojang sessionserver authentication - secure and automatic
+     * @param gambits List of gambits with name and description
+     */
+    public static void uploadGambits(List<julianh06.wynnextras.features.aspects.GambitData.GambitEntry> gambits) {
+        if (McUtils.player() == null) {
+            System.err.println("Cannot upload gambits - player not loaded");
+            return;
+        }
+
+        // Authenticate with Mojang first
+        julianh06.wynnextras.utils.MojangAuth.getAuthData().thenAccept(authData -> {
+            if (authData == null) {
+                System.err.println("Failed to authenticate with Mojang");
+                return;
+            }
+
+            try {
+                // Build JSON payload
+                JsonObject payload = new JsonObject();
+                JsonArray gambitsArray = new JsonArray();
+
+                for (julianh06.wynnextras.features.aspects.GambitData.GambitEntry gambit : gambits) {
+                    JsonObject gambitJson = new JsonObject();
+                    gambitJson.addProperty("name", gambit.name);
+                    gambitJson.addProperty("description", gambit.description);
+                    gambitsArray.add(gambitJson);
+                }
+
+                payload.add("gambits", gambitsArray);
+
+                HttpClient client = HttpClient.newBuilder()
+                        .connectTimeout(Duration.ofSeconds(5))
+                        .build();
+
+                HttpRequest request = HttpRequest.newBuilder()
+                        .uri(URI.create("http://wynnextras.com/gambit"))
+                        .header("Content-Type", "application/json")
+                        .header("Username", authData.username)
+                        .header("Server-ID", authData.serverId)
+                        .POST(HttpRequest.BodyPublishers.ofString(payload.toString()))
+                        .timeout(Duration.ofSeconds(8))
+                        .build();
+
+                client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                        .thenAccept(response -> {
+                            int code = response.statusCode();
+                            if (code == 200) {
+                                JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject();
+                                String status = result.get("status").getAsString();
+
+                                if (status.equals("approved")) {
+                                    McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§aGambits approved for today!"));
+                                } else {
+                                    McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§7Gambits submitted. Waiting for confirmation."));
+                                }
+                            } else if (code == 401) {
+                                McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§cAuthentication failed"));
+                            } else {
+                                McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§cError uploading gambits: " + code));
+                            }
+                        })
+                        .exceptionally(ex -> {
+                            System.err.println("Failed to upload gambits: " + ex.getMessage());
+                            return null;
+                        });
+
+            } catch (Exception e) {
+                e.printStackTrace();
+                McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix("§cError preparing gambits upload"));
+            }
+        });
+    }
+
+    /**
+     * Extract required class from tier info string
+     * Format: "Class Req: Warrior" or similar
+     */
+    private static String extractRequiredClass(String tierInfo) {
+        if (tierInfo == null) return null;
+
+        String[] lines = tierInfo.split("\n");
+        for (String line : lines) {
+            if (line.contains("Class Req:")) {
+                return line.replace("Class Req:", "").trim();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Fetch list of all players who have uploaded aspects
+     * @return CompletableFuture with list of player entries sorted by most recent
+     */
+    public static CompletableFuture<List<PlayerListEntry>> fetchPlayerList() {
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(3))
+                    .build();
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("http://wynnextras.com/aspects/list"))
+                    .timeout(Duration.ofSeconds(5))
+                    .GET()
+                    .build();
+
+            return client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                    .thenApply(response -> {
+                        if (response.statusCode() != 200) {
+                            System.out.println("Failed to fetch player list: " + response.statusCode());
+                            return new ArrayList<PlayerListEntry>();
+                        }
+
+                        try {
+                            JsonArray json = JsonParser.parseString(response.body()).getAsJsonArray();
+                            List<PlayerListEntry> result = new ArrayList<>();
+
+                            for (int i = 0; i < json.size(); i++) {
+                                JsonObject entry = json.get(i).getAsJsonObject();
+                                PlayerListEntry player = gson.fromJson(entry, PlayerListEntry.class);
+                                result.add(player);
+                            }
+
+                            // Deduplicate by playerUuid (keep first occurrence, which is most recent)
+                            Set<String> seen = new HashSet<>();
+                            result = result.stream()
+                                    .filter(p -> seen.add(p.getPlayerUuid()))
+                                    .collect(Collectors.toList());
+
+                            System.out.println("Fetched " + result.size() + " players from list");
+                            return result;
+                        } catch (Exception e) {
+                            System.err.println("Error parsing player list: " + e.getMessage());
+                            return new ArrayList<PlayerListEntry>();
+                        }
+                    })
+                    .exceptionally(ex -> {
+                        System.err.println("Failed to fetch player list: " + ex.getMessage());
+                        return new ArrayList<PlayerListEntry>();
+                    });
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return CompletableFuture.completedFuture(new ArrayList<PlayerListEntry>());
+        }
+    }
+
+    /**
+     * Fetch leaderboard of players with most maxed aspects
+     * @param limit Number of entries (default 15, max 100)
+     * @return CompletableFuture with list of leaderboard entries
+     */
+    public static CompletableFuture<List<LeaderboardEntry>> fetchLeaderboard(int limit) {
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(3))
+                    .build();
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("http://wynnextras.com/aspects/leaderboard?limit=" + limit))
+                    .timeout(Duration.ofSeconds(5))
+                    .GET()
+                    .build();
+
+            System.out.println("[WynnExtras] Fetching leaderboard from: http://wynnextras.com/aspects/leaderboard?limit=" + limit);
+
+            return client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                    .thenApply(response -> {
+                        System.out.println("[WynnExtras] Leaderboard response code: " + response.statusCode());
+                        System.out.println("[WynnExtras] Leaderboard response body: " + response.body().substring(0, Math.min(500, response.body().length())));
+
+                        if (response.statusCode() != 200) {
+                            System.out.println("Failed to fetch leaderboard: " + response.statusCode());
+                            return new ArrayList<LeaderboardEntry>();
+                        }
+
+                        try {
+                            JsonArray json = JsonParser.parseString(response.body()).getAsJsonArray();
+                            List<LeaderboardEntry> result = new ArrayList<>();
+
+                            for (int i = 0; i < json.size(); i++) {
+                                JsonObject entry = json.get(i).getAsJsonObject();
+                                LeaderboardEntry player = gson.fromJson(entry, LeaderboardEntry.class);
+                                result.add(player);
+                                System.out.println("[WynnExtras] Parsed leaderboard entry: " + player.getPlayerName() + " - " + player.getMaxAspectCount() + " maxed");
+                            }
+
+                            System.out.println("[WynnExtras] Fetched " + result.size() + " leaderboard entries");
+                            return result;
+                        } catch (Exception e) {
+                            System.err.println("Error parsing leaderboard: " + e.getMessage());
+                            e.printStackTrace();
+                            return new ArrayList<LeaderboardEntry>();
+                        }
+                    })
+                    .exceptionally(ex -> {
+                        System.err.println("Failed to fetch leaderboard: " + ex.getMessage());
+                        ex.printStackTrace();
+                        return new ArrayList<LeaderboardEntry>();
+                    });
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return CompletableFuture.completedFuture(new ArrayList<LeaderboardEntry>());
+        }
+    }
+
+    /**
+     * Fetch crowdsourced loot pool from API
+     * @param raidType NOTG, NOL, TCC, TNA
+     * @return CompletableFuture with list of aspects or null if not available
+     */
+    public static CompletableFuture<List<julianh06.wynnextras.features.aspects.LootPoolData.AspectEntry>> fetchCrowdsourcedLootPool(String raidType) {
+        try {
+            // Validate raid type (short codes only)
+            if (!raidType.equals("NOTG") && !raidType.equals("NOL") &&
+                !raidType.equals("TCC") && !raidType.equals("TNA")) {
+                System.err.println("Unknown raid type: " + raidType);
+                return CompletableFuture.completedFuture(null);
+            }
+
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(3))
+                    .build();
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("http://wynnextras.com/raid/loot-pool?raidType=" + raidType))
+                    .timeout(Duration.ofSeconds(5))
+                    .GET()
+                    .build();
+
+            return client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                    .thenApply(response -> {
+                        if (response.statusCode() != 200) {
+                            System.out.println("No crowdsourced loot pool for " + raidType + ": " + response.statusCode());
+                            return null;
+                        }
+
+                        try {
+                            JsonObject json = JsonParser.parseString(response.body()).getAsJsonObject();
+                            JsonArray aspects = json.getAsJsonArray("aspects");
+
+                            List<julianh06.wynnextras.features.aspects.LootPoolData.AspectEntry> result = new ArrayList<>();
+                            for (int i = 0; i < aspects.size(); i++) {
+                                JsonObject aspect = aspects.get(i).getAsJsonObject();
+                                String name = aspect.get("name").getAsString();
+                                String rarity = aspect.get("rarity").getAsString();
+                                String requiredClass = aspect.has("requiredClass") && !aspect.get("requiredClass").isJsonNull()
+                                        ? aspect.get("requiredClass").getAsString() : null;
+
+                                result.add(new julianh06.wynnextras.features.aspects.LootPoolData.AspectEntry(
+                                        name, rarity, "", ""
+                                ));
+                            }
+
+                            System.out.println("Fetched " + result.size() + " aspects from crowdsourced pool for " + raidType);
+                            return result;
+                        } catch (Exception e) {
+                            System.err.println("Error parsing crowdsourced loot pool: " + e.getMessage());
+                            return null;
+                        }
+                    })
+                    .exceptionally(ex -> {
+                        System.err.println("Failed to fetch crowdsourced loot pool: " + ex.getMessage());
+                        return null;
+                    });
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    /**
+     * Fetch crowdsourced gambits from API
+     * @return CompletableFuture with list of gambits or null if not available
+     */
+    public static CompletableFuture<List<julianh06.wynnextras.features.aspects.GambitData.GambitEntry>> fetchCrowdsourcedGambits() {
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(3))
+                    .build();
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("http://wynnextras.com/gambit"))
+                    .timeout(Duration.ofSeconds(5))
+                    .GET()
+                    .build();
+
+            return client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                    .thenApply(response -> {
+                        if (response.statusCode() != 200) {
+                            System.out.println("No crowdsourced gambits: " + response.statusCode());
+                            return null;
+                        }
+
+                        try {
+                            JsonObject json = JsonParser.parseString(response.body()).getAsJsonObject();
+                            JsonArray gambits = json.getAsJsonArray("gambits");
+
+                            List<julianh06.wynnextras.features.aspects.GambitData.GambitEntry> result = new ArrayList<>();
+                            for (int i = 0; i < gambits.size(); i++) {
+                                JsonObject gambit = gambits.get(i).getAsJsonObject();
+                                String name = gambit.get("name").getAsString();
+                                String description = gambit.get("description").getAsString();
+
+                                result.add(new julianh06.wynnextras.features.aspects.GambitData.GambitEntry(name, description));
+                            }
+
+                            System.out.println("Fetched " + result.size() + " gambits from crowdsourced data");
+                            return result;
+                        } catch (Exception e) {
+                            System.err.println("Error parsing crowdsourced gambits: " + e.getMessage());
+                            return null;
+                        }
+                    })
+                    .exceptionally(ex -> {
+                        System.err.println("Failed to fetch crowdsourced gambits: " + ex.getMessage());
+                        return null;
+                    });
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return CompletableFuture.completedFuture(null);
+        }
+    }
 
 
     public static CompletableFuture<AbilityMapData> fetchPlayerAbilityMap(String playerUUID, String characterUUUID) {
-        HttpClient client = HttpClient.newHttpClient();
         HttpRequest request;
 
         if (INSTANCE.API_KEY == null) {
@@ -453,35 +1065,29 @@ public class WynncraftApiHandler {
                     .build();
         }
 
-        return client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+        return HTTP_CLIENT.sendAsync(request, HttpResponse.BodyHandlers.ofString())
                 .thenApply(HttpResponse::body)
                 .thenApply(WynncraftApiHandler::parseAbilityMapData);
     }
 
     public static CompletableFuture<AbilityMapData> fetchClassAbilityMap(String className) {
-        HttpClient client = HttpClient.newHttpClient();
-        HttpRequest request;
-
-        request = HttpRequest.newBuilder()
+        HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create("https://api.wynncraft.com/v3/ability/map/" + className))
                 .GET()
                 .build();
 
-        return client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+        return HTTP_CLIENT.sendAsync(request, HttpResponse.BodyHandlers.ofString())
                 .thenApply(HttpResponse::body)
                 .thenApply(WynncraftApiHandler::parseAbilityMapData);
     }
 
     public static CompletableFuture<AbilityTreeData> fetchClassAbilityTree(String className) {
-        HttpClient client = HttpClient.newHttpClient();
-        HttpRequest request;
-
-        request = HttpRequest.newBuilder()
+        HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create("https://api.wynncraft.com/v3/ability/tree/" + className))
                 .GET()
                 .build();
 
-        return client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+        return HTTP_CLIENT.sendAsync(request, HttpResponse.BodyHandlers.ofString())
                 .thenApply(HttpResponse::body)
                 .thenApply(WynncraftApiHandler::parseAbilityTreeData);
     }
@@ -507,8 +1113,6 @@ public class WynncraftApiHandler {
     }
 
     private static List<ApiAspect> parseAspectData(String json) {
-        System.out.println(json);
-
         Gson gson = new GsonBuilder()
                 .registerTypeAdapter(ApiAspect.Icon.class, new ApiAspect.IconDeserializer())
                 .create();
@@ -547,6 +1151,11 @@ public class WynncraftApiHandler {
 
 
     public static void load() {
+        if (McUtils.player() == null) {
+            System.err.println("[WynnExtras] Cannot load API key - player not loaded");
+            return;
+        }
+
         Path CONFIG_PATH = FabricLoader.getInstance()
                 .getConfigDir()
                 .resolve("wynnextras/" + McUtils.player().getUuid().toString() + "/apikeyDoNotShare.json");
@@ -566,6 +1175,11 @@ public class WynncraftApiHandler {
     }
 
     public static void save() {
+        if (McUtils.player() == null) {
+            System.err.println("[WynnExtras] Cannot save API key - player not loaded");
+            return;
+        }
+
         Path CONFIG_PATH = FabricLoader.getInstance()
                 .getConfigDir()
                 .resolve("wynnextras/" + McUtils.player().getUuid().toString() + "/apikeyDoNotShare.json");

--- a/src/main/java/julianh06/wynnextras/features/profileviewer/data/PlayerListEntry.java
+++ b/src/main/java/julianh06/wynnextras/features/profileviewer/data/PlayerListEntry.java
@@ -1,0 +1,37 @@
+package julianh06.wynnextras.features.profileviewer.data;
+
+/**
+ * Represents a player entry from /user/list endpoint
+ */
+public class PlayerListEntry {
+    private String playerUuid;
+    private String playerName;
+    private String modVersion;
+    private long lastUpdated;
+    private int aspectCount;
+    private int maxAspectCount; // Number of maxed aspects (if provided by API)
+
+    public String getPlayerUuid() {
+        return playerUuid;
+    }
+
+    public String getPlayerName() {
+        return playerName;
+    }
+
+    public String getModVersion() {
+        return modVersion;
+    }
+
+    public long getLastUpdated() {
+        return lastUpdated;
+    }
+
+    public int getAspectCount() {
+        return aspectCount;
+    }
+
+    public int getMaxAspectCount() {
+        return maxAspectCount;
+    }
+}


### PR DESCRIPTION
## Summary

### New features:
- **AspectScreenSimple**: Full aspect management screen with 6 pages
  - Loot Pools: View raid aspect loot pools with crowdsourced data
  - My Aspects: View your own aspects with class filtering
  - Gambits: View daily gambits with countdown timer
  - Raid Loot: Track raid loot statistics
  - Explore: Browse other players' aspects
  - Leaderboard: Top players with most maxed aspects
- **GambitNotifier**: Notifies players about gambit resets
- **FavoriteAspectsData**: Track favorite aspects across sessions
- **LootPoolData**: Store and manage loot pool data locally
- **ScreenTitleDebugger**: Debug tool for finding menu identifiers

### UI improvements:
- Textured buttons using `ui.drawButtonFade` for Wynncraft style
- Rainbow color for all maxed aspect names
- Larger navigation buttons (210px) for better text fit
- Explore page shows "Total | Max" format when available

### API additions:
- PlayerListEntry with maxAspectCount field
- WynncraftApiHandler methods for aspect data fetching

## Test plan
- [ ] Open `/we aspects` and verify all 6 pages work
- [ ] Check textured buttons display correctly on all pages
- [ ] Verify maxed aspects show rainbow text on Loot Pools page
- [ ] Verify maxed aspects show rainbow text on My Aspects page
- [ ] Test gambit notifications near reset time
- [ ] Test Explore page player browsing
- [ ] Test Leaderboard page