### PR TITLE
Add redirect option to open profile viewer instead of stats browser page

### DIFF
--- a/src/main/java/julianh06/wynnextras/config/WynnExtrasConfig.java
+++ b/src/main/java/julianh06/wynnextras/config/WynnExtrasConfig.java
@@ -147,6 +147,7 @@ public class WynnExtrasConfig {
     public TextColor provokeTimerColor = TextColor.WHITE;
     public boolean differentGUIScale = false;
     public boolean showLootpoolButtonInPartyFinder = true;
+    public boolean redirectWynntilsViewStatsToPV = true;
 
     public boolean showOwnNametag = false;
     // The code for this is in LivingEntityRendererMixin

--- a/src/main/java/julianh06/wynnextras/config/WynnExtrasConfigScreen.java
+++ b/src/main/java/julianh06/wynnextras/config/WynnExtrasConfigScreen.java
@@ -322,6 +322,8 @@ public class WynnExtrasConfigScreen extends Screen {
                 () -> config.differentGUIScale, v -> config.differentGUIScale = v))
             .add(slider("GUI Scale", "Custom GUI scale value",
             1, 5, () -> config.customGUIScale, v -> config.customGUIScale = v))
+            .add(toggle("Redirect Wynntils View Stats", "Changes the Wynntils Player Viewer's 'View Player Stats' button to open the Profile Viewer instead of the website stats page",
+                () -> config.redirectWynntilsViewStatsToPV, v -> config.redirectWynntilsViewStatsToPV = v))
             .add(toggle("Skip Front View", "Skip front-facing view in 3rd person",
                 () -> config.removeFrontPersonView, v -> config.removeFrontPersonView = v))
             .add(toggle("Financial Advice", "Receive smart financial advise in the Identifier menu",

--- a/src/main/java/julianh06/wynnextras/mixin/NetManagerMixin.java
+++ b/src/main/java/julianh06/wynnextras/mixin/NetManagerMixin.java
@@ -1,0 +1,27 @@
+package julianh06.wynnextras.mixin;
+
+import com.wynntils.core.net.NetManager;
+import com.wynntils.core.net.UrlId;
+import julianh06.wynnextras.config.WynnExtrasConfig;
+import julianh06.wynnextras.features.profileviewer.PV;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Map;
+
+@Mixin(NetManager.class)
+public class NetManagerMixin {
+    @Inject(method = "openLink(Lcom/wynntils/core/net/UrlId;Ljava/util/Map;)V", at = @At("HEAD"), cancellable = true)
+    private void onOpenLink(UrlId urlId, Map<String, String> arguments, CallbackInfo ci) {
+        if (!WynnExtrasConfig.INSTANCE.redirectWynntilsViewStatsToPV) return;
+        if (urlId != UrlId.LINK_WYNNCRAFT_PLAYER_STATS || arguments == null) return;
+
+        String username = arguments.get("username");
+        if (username == null || username.isBlank()) return;
+
+        PV.open(username);
+        ci.cancel();
+    }
+}

--- a/src/main/resources/wynnextras.mixins.json
+++ b/src/main/resources/wynnextras.mixins.json
@@ -18,6 +18,7 @@
     "ItemHighlightFeatureMixin",
     "LivingEntityRendererMixin",
     "MouseScrollMixin",
+    "NetManagerMixin",
     "PerspectiveMixin",
     "RaidLootOverlayClickMixin",
     "RaidLootOverlayScreenMixin",


### PR DESCRIPTION
#### Adds a config (default true) to open profile viewer instead of browser from wynntils player viewer "view stats" button

<img width="429" height="306" alt="javaw_2026-03-25_15 56 32" src="https://github.com/user-attachments/assets/a6020363-b072-417f-8efe-c17b7b5b8589" />


​
#### Also, hit developer Teslanator left me on read smh
<img width="661" height="41" alt="javaw_2026-03-25_15 57 43" src="https://github.com/user-attachments/assets/f3f42a35-2799-4777-aec0-3f9210a157fc" />
