### PR TITLE
Fix GUI freeze when opening any screen

### DIFF
--- a/src/main/java/julianh06/wynnextras/features/bankoverlay/BankOverlay2.java
+++ b/src/main/java/julianh06/wynnextras/features/bankoverlay/BankOverlay2.java
@@ -156,6 +156,8 @@ public class BankOverlay2 extends WEHandledScreen {
 
     private static Pair<Integer, Integer> lastClickedSlot = new Pair<>(-1, -1);
 
+    private static boolean wynncraftItemDatabaseInitialized = false;
+
     public BankOverlay2(CallbackInfo ci, HandledScreen<?> screen) {
         this.ci = ci;
         this.screen = screen;
@@ -178,12 +180,17 @@ public class BankOverlay2 extends WEHandledScreen {
         scissorx2 = 0;
         scissory2 = 0;
 
-        try {
-            if (FabricLoader.getInstance().isModLoaded("wynnmod")) {
-                Class<?> clazz = Class.forName("com.wynnmod.wynncraft.item.map.WynncraftItemDatabase");
-                clazz.getMethod("initialize").invoke(null);
+        if (!wynncraftItemDatabaseInitialized) {
+            try {
+                if (FabricLoader.getInstance().isModLoaded("wynnmod")) {
+                    Class<?> clazz = Class.forName("com.wynnmod.wynncraft.item.map.WynncraftItemDatabase");
+                    clazz.getMethod("initialize").invoke(null);
+                }
+                wynncraftItemDatabaseInitialized = true;
+            } catch (Exception ignored) {
+                wynncraftItemDatabaseInitialized = true;
             }
-        } catch (Exception ignored) {}
+        }
     }
 
 

--- a/src/main/java/julianh06/wynnextras/mixin/BankOverlay/HandledScreenMixin.java
+++ b/src/main/java/julianh06/wynnextras/mixin/BankOverlay/HandledScreenMixin.java
@@ -6,6 +6,10 @@ import com.wynntils.models.containers.containers.CharacterInfoContainer;
 import com.wynntils.models.containers.containers.CharacterSelectionContainer;
 import com.wynntils.models.containers.containers.CraftingStationContainer;
 import com.wynntils.models.containers.containers.ItemIdentifierContainer;
+import com.wynntils.models.containers.containers.personal.AccountBankContainer;
+import com.wynntils.models.containers.containers.personal.BookshelfContainer;
+import com.wynntils.models.containers.containers.personal.CharacterBankContainer;
+import com.wynntils.models.containers.containers.personal.MiscBucketContainer;
 import com.wynntils.utils.mc.McUtils;
 import julianh06.wynnextras.config.WynnExtrasConfig;
 import julianh06.wynnextras.annotations.WEModule;
@@ -51,6 +55,7 @@ public abstract class HandledScreenMixin {
     @Shadow protected int y;
 
     @Unique private julianh06.wynnextras.features.bankoverlay.BankOverlay2 bankOverlay;
+    @Unique private Boolean isBankScreen = null;
 
     @Unique private IdentifierOverlay identifierOverlay;
 
@@ -69,14 +74,28 @@ public abstract class HandledScreenMixin {
     
     @Inject(method = "render", at = @At("HEAD"), cancellable = true)
     private void renderInventory(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
-        if(bankOverlay == null) bankOverlay = new BankOverlay2(ci, (HandledScreen<?>) (Object) this);
-        bankOverlay.ci = ci;
-        bankOverlay.screen = (HandledScreen<?>) (Object) this;
-        bankOverlay.close = close -> {
-            close();
-            return null;
-        };
-        bankOverlay.render(context, mouseX, mouseY, delta);
+        // Only create BankOverlay2 for bank-type containers to avoid expensive
+        // initialization (WynncraftItemDatabase.initialize()) on every GUI open
+        if (isBankScreen == null) {
+            Container container = Models.Container.getCurrentContainer();
+            if (container != null) {
+                isBankScreen = container instanceof AccountBankContainer ||
+                    container instanceof CharacterBankContainer ||
+                    container instanceof BookshelfContainer ||
+                    container instanceof MiscBucketContainer;
+            }
+        }
+
+        if (Boolean.TRUE.equals(isBankScreen) || currentOverlayType != BankOverlayType.NONE) {
+            if (bankOverlay == null) bankOverlay = new BankOverlay2(ci, (HandledScreen<?>) (Object) this);
+            bankOverlay.ci = ci;
+            bankOverlay.screen = (HandledScreen<?>) (Object) this;
+            bankOverlay.close = close -> {
+                close();
+                return null;
+            };
+            bankOverlay.render(context, mouseX, mouseY, delta);
+        }
 
         if(WynnExtrasConfig.INSTANCE.sourceOfTruthToggle) {
             if (identifierOverlay == null) {

--- a/src/main/java/julianh06/wynnextras/mixin/PressableWidgetMixin.java
+++ b/src/main/java/julianh06/wynnextras/mixin/PressableWidgetMixin.java
@@ -17,8 +17,12 @@ public class PressableWidgetMixin {
     @Inject(method = "renderWidget", at = @At(value = "HEAD"), cancellable = true)
     void renderWidget(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
         try {
-            if((Models.Container.getCurrentContainer() instanceof CraftingStationContainer) && WynnExtrasConfig.INSTANCE.craftingHelperOverlay) ci.cancel();
-            if(BankOverlay.currentOverlayType != BankOverlayType.NONE && WynnExtrasConfig.INSTANCE.toggleBankOverlay) ci.cancel();
+            // Check cheap static field first to avoid expensive getCurrentContainer() call
+            if(BankOverlay.currentOverlayType != BankOverlayType.NONE && WynnExtrasConfig.INSTANCE.toggleBankOverlay) {
+                ci.cancel();
+                return;
+            }
+            if(WynnExtrasConfig.INSTANCE.craftingHelperOverlay && Models.Container.getCurrentContainer() instanceof CraftingStationContainer) ci.cancel();
         } catch (Exception ignored) {}
     }
 }


### PR DESCRIPTION
## Summary
- **BankOverlay2** was being constructed for every `HandledScreen` (trade market, crafting stations, NPCs, etc.), not just bank containers. Each construction called `WynncraftItemDatabase.initialize()` via reflection, causing a **500ms+ freeze** on every GUI open.
- Multiple users in guild chat confirmed the issue: "anyone elses menus lagging a lot?", "is it just me lagging everytime I open a new UI?", "it s very laggy for like 2 secs everytime"

## Changes
- **BankOverlay2**: Make `WynncraftItemDatabase.initialize()` a one-time static call instead of running on every construction
- **HandledScreenMixin**: Only create `BankOverlay2` for actual bank containers (`AccountBank`, `CharacterBank`, `Bookshelf`, `MiscBucket`) — non-bank GUIs skip the entire bank overlay code path
- **PressableWidgetMixin**: Check cheap static `currentOverlayType` field first with early return, avoiding expensive `getCurrentContainer()` call on every widget render

## Test plan
- [ ] Open trade market — no freeze
- [ ] Open crafting station — no freeze
- [ ] Open NPC dialog — no freeze
- [ ] Open account/character bank — bank overlay still works correctly
- [ ] Bank quick toggle button still appears when `bankQuickToggle` is enabled
- [ ] Search, page navigation, and all bank overlay features still work