### PR TITLE
Bank Overlay Rendering Fixes

### DIFF
--- a/src/main/java/julianh06/wynnextras/features/bankoverlay/BankOverlay2.java
+++ b/src/main/java/julianh06/wynnextras/features/bankoverlay/BankOverlay2.java
@@ -215,14 +215,15 @@ public class BankOverlay2 extends WEHandledScreen {
 
         int xStart = xRemain / 2 - 2;
         int yStart = yRemain / 2 - 2;
+        int buttonWidgetsX = (int) ((xStart + (xFitAmount / 2) * (162 + 4) - 166) * ui.getScaleFactor());
 
         if(currentOverlayType != BankOverlayType.NONE && expectedOverlayType != BankOverlayType.NONE && currentOverlayType != expectedOverlayType) {
             RenderUtils.drawRect(context, CustomColor.fromInt(-804253680), 0, 0, mc.currentScreen.width, mc.currentScreen.height);
             drawBackgroundRect(context, xRemain, yRemain);
             if(WynnExtrasConfig.INSTANCE.darkmodeToggle) {
-                ui.drawImage((currentOverlayType == BankOverlayType.ACCOUNT || currentOverlayType == BankOverlayType.CHARACTER) ? buttonBackgroundDark : buttonBackgroundShortDark, xStart - 8, yStart + (yFitAmount - 1) * (104) - 8, (int) (170 * ui.getScaleFactor()), (int) (91 * ui.getScaleFactor()));
+                ui.drawImage((currentOverlayType == BankOverlayType.ACCOUNT || currentOverlayType == BankOverlayType.CHARACTER) ? buttonBackgroundDark : buttonBackgroundShortDark, buttonWidgetsX - 8, yStart + (yFitAmount - 1) * (104) - 8, (int) (170 * ui.getScaleFactor()), (int) (91 * ui.getScaleFactor()));
             } else {
-                ui.drawImage((currentOverlayType == BankOverlayType.ACCOUNT || currentOverlayType == BankOverlayType.CHARACTER) ? buttonBackground : buttonBackgroundShort, xStart - 8, yStart + (yFitAmount - 1) * (104) - 8, (int) (170 * ui.getScaleFactor()), (int) (91 * ui.getScaleFactor()));
+                ui.drawImage((currentOverlayType == BankOverlayType.ACCOUNT || currentOverlayType == BankOverlayType.CHARACTER) ? buttonBackground : buttonBackgroundShort, buttonWidgetsX - 8, yStart + (yFitAmount - 1) * (104) - 8, (int) (170 * ui.getScaleFactor()), (int) (91 * ui.getScaleFactor()));
             }
             if(inventoryWidget != null) inventoryWidget.draw(context, mouseX, mouseY, delta, ui);
             if(quickActionWidget != null) quickActionWidget.draw(context, mouseX, mouseY, delta, ui);
@@ -517,29 +518,28 @@ public class BankOverlay2 extends WEHandledScreen {
 
             context.disableScissor();
 
-            xStart = (int) ((xStart + (xFitAmount / 2) * (162 + 4) - 166) * ui.getScaleFactor());
-            inventoryWidget.setBounds(xStart + 160, yStart + (yFitAmount - 1) * (90 + 4 + 10) - 3, (int) (176 * ui.getScaleFactor()), (int) (86 * ui.getScaleFactor()));
+            inventoryWidget.setBounds(buttonWidgetsX + 160, yStart + (yFitAmount - 1) * (90 + 4 + 10) - 3, (int) (176 * ui.getScaleFactor()), (int) (86 * ui.getScaleFactor()));
             inventoryWidget.setItems(buildInventoryForIndex(0, true));
             inventoryWidget.updateValues();
             inventoryWidget.draw(context, mouseX, mouseY, delta, ui);
 
             if(currentOverlayType == BankOverlayType.ACCOUNT || currentOverlayType == BankOverlayType.CHARACTER) {
-                switchButtonWidget.setBounds(xStart, yStart + (yFitAmount - 1) * (90 + 4 + 10) + 3, (int) (155 * ui.getScaleFactor()), (int) (23 * ui.getScaleFactor()));
+                switchButtonWidget.setBounds(buttonWidgetsX, yStart + (yFitAmount - 1) * (90 + 4 + 10) + 3, (int) (155 * ui.getScaleFactor()), (int) (23 * ui.getScaleFactor()));
                 switchButtonWidget.draw(context, mouseX, mouseY, delta, ui);
             } else {
                 switchButtonWidget.setBounds(0, 0, 0, 0);
             }
 
             if(WynnExtrasConfig.INSTANCE.darkmodeToggle) {
-                ui.drawImage((currentOverlayType == BankOverlayType.ACCOUNT || currentOverlayType == BankOverlayType.CHARACTER) ? buttonBackgroundDark : buttonBackgroundShortDark, xStart - 8, yStart + (yFitAmount - 1) * (104) - 8, (int) (170 * ui.getScaleFactor()), (int) (91 * ui.getScaleFactor()));
+                ui.drawImage((currentOverlayType == BankOverlayType.ACCOUNT || currentOverlayType == BankOverlayType.CHARACTER) ? buttonBackgroundDark : buttonBackgroundShortDark, buttonWidgetsX - 8, yStart + (yFitAmount - 1) * (104) - 8, (int) (170 * ui.getScaleFactor()), (int) (91 * ui.getScaleFactor()));
             } else {
-                ui.drawImage((currentOverlayType == BankOverlayType.ACCOUNT || currentOverlayType == BankOverlayType.CHARACTER) ? buttonBackground : buttonBackgroundShort, xStart - 8, yStart + (yFitAmount - 1) * (104) - 8, (int) (170 * ui.getScaleFactor()), (int) (91 * ui.getScaleFactor()));
+                ui.drawImage((currentOverlayType == BankOverlayType.ACCOUNT || currentOverlayType == BankOverlayType.CHARACTER) ? buttonBackground : buttonBackgroundShort, buttonWidgetsX - 8, yStart + (yFitAmount - 1) * (104) - 8, (int) (170 * ui.getScaleFactor()), (int) (91 * ui.getScaleFactor()));
             }
 
             if(currentOverlayType == BankOverlayType.ACCOUNT || currentOverlayType == BankOverlayType.CHARACTER) {
-                searchbar2.setBounds(xStart, yStart + (yFitAmount - 1) * (90 + 4 + 10) + 59, (int) (155 * ui.getScaleFactor()), (int) (23 * ui.getScaleFactor()));
+                searchbar2.setBounds(buttonWidgetsX, yStart + (yFitAmount - 1) * (90 + 4 + 10) + 59, (int) (155 * ui.getScaleFactor()), (int) (23 * ui.getScaleFactor()));
             } else {
-                searchbar2.setBounds(xStart, yStart + (yFitAmount - 1) * (90 + 4 + 10) + 31, (int) (155 * ui.getScaleFactor()), (int) (23 * ui.getScaleFactor()));
+                searchbar2.setBounds(buttonWidgetsX, yStart + (yFitAmount - 1) * (90 + 4 + 10) + 31, (int) (155 * ui.getScaleFactor()), (int) (23 * ui.getScaleFactor()));
             }
 
             searchbar2.setTextColor(CustomColor.fromHexString("FFFFFF"));
@@ -547,12 +547,12 @@ public class BankOverlay2 extends WEHandledScreen {
             searchbar2.draw(context, mouseX, mouseY, delta, ui);
 
             if(currentOverlayType == BankOverlayType.ACCOUNT || currentOverlayType == BankOverlayType.CHARACTER) {
-                ui.drawCenteredText("Switch to " + (currentOverlayType == BankOverlayType.ACCOUNT ? "Character" : "Account") + " Bank", xStart + (77 * ui.getScaleFactorF()), yStart + (yFitAmount - 1) * (104) + 14, CustomColor.fromHexString("FFFFFF"), 1.1f);
+                ui.drawCenteredText("Switch to " + (currentOverlayType == BankOverlayType.ACCOUNT ? "Character" : "Account") + " Bank", buttonWidgetsX + (77 * ui.getScaleFactorF()), yStart + (yFitAmount - 1) * (104) + 14, CustomColor.fromHexString("FFFFFF"), 1.1f);
             }
             if(currentOverlayType == BankOverlayType.ACCOUNT || currentOverlayType == BankOverlayType.CHARACTER) {
-                ui.drawCenteredText("Quick Actions", xStart + (77 * ui.getScaleFactorF()), yStart + (yFitAmount - 1) * (104) + 44, CustomColor.fromHexString("FFFFFF"), 1.1f);
+                ui.drawCenteredText("Quick Actions", buttonWidgetsX + (77 * ui.getScaleFactorF()), yStart + (yFitAmount - 1) * (104) + 44, CustomColor.fromHexString("FFFFFF"), 1.1f);
             } else {
-                ui.drawCenteredText("Quick Actions", xStart + (77 * ui.getScaleFactorF()), yStart + (yFitAmount - 1) * (104) + 14, CustomColor.fromHexString("FFFFFF"), 1.1f);
+                ui.drawCenteredText("Quick Actions", buttonWidgetsX + (77 * ui.getScaleFactorF()), yStart + (yFitAmount - 1) * (104) + 14, CustomColor.fromHexString("FFFFFF"), 1.1f);
             }
         }
 
@@ -565,9 +565,9 @@ public class BankOverlay2 extends WEHandledScreen {
         renderHeldItemOverlay(context, mouseX, mouseY);
 
         if(currentOverlayType == BankOverlayType.ACCOUNT || currentOverlayType == BankOverlayType.CHARACTER) {
-            quickActionWidget.setBounds(xStart, yStart + (yFitAmount - 1) * (90 + 4 + 10) + 31, (int) (155 * ui.getScaleFactor()), (int) (23 * ui.getScaleFactor()));
+            quickActionWidget.setBounds(buttonWidgetsX, yStart + (yFitAmount - 1) * (90 + 4 + 10) + 31, (int) (155 * ui.getScaleFactor()), (int) (23 * ui.getScaleFactor()));
         } else {
-            quickActionWidget.setBounds(xStart, yStart + (yFitAmount - 1) * (90 + 4 + 10) + 3, (int) (155 * ui.getScaleFactor()), (int) (23 * ui.getScaleFactor()));
+            quickActionWidget.setBounds(buttonWidgetsX, yStart + (yFitAmount - 1) * (90 + 4 + 10) + 3, (int) (155 * ui.getScaleFactor()), (int) (23 * ui.getScaleFactor()));
         }
 
         quickActionWidget.draw(context, mouseX, mouseY, delta, ui);

--- a/src/main/java/julianh06/wynnextras/features/bankoverlay/BankOverlay2.java
+++ b/src/main/java/julianh06/wynnextras/features/bankoverlay/BankOverlay2.java
@@ -672,6 +672,15 @@ public class BankOverlay2 extends WEHandledScreen {
         xFitAmount = Math.min(xFitAmount, WynnExtrasConfig.INSTANCE.bankOverlayMaxColumns);
         yFitAmount = Math.min(yFitAmount, WynnExtrasConfig.INSTANCE.bankOverlayMaxRows + 1);
 
+        if (currentData != null && currentData.lastPage > 0) {
+            int totalPages = currentData.lastPage;
+            int rowsNeeded = (int) Math.ceil((double) totalPages / xFitAmount);
+
+            if (rowsNeeded < yFitAmount) {
+                yFitAmount = rowsNeeded + 1;
+            }
+        }
+
         int xRemain = screenWidth - xFitAmount * 162 - (xFitAmount - 1) * 4;
         if (xRemain < 0) {
             xFitAmount--;

--- a/src/main/java/julianh06/wynnextras/features/bankoverlay/BankOverlay2.java
+++ b/src/main/java/julianh06/wynnextras/features/bankoverlay/BankOverlay2.java
@@ -386,7 +386,7 @@ public class BankOverlay2 extends WEHandledScreen {
             scissorx1 = xStart - 5;
             scissory1 = yStart;
             scissorx2 = xStart + 166 * xFitAmount;
-            scissory2 = yStart + 100 * (yFitAmount - 1);
+            scissory2 = yStart + 104 * (yFitAmount - 1) - 12;
 
             context.enableScissor(scissorx1, scissory1, scissorx2, scissory2);
             ui.updateContext(context, ui.getScaleFactor(), 0, 0);

--- a/src/main/java/julianh06/wynnextras/features/bankoverlay/BankOverlay2.java
+++ b/src/main/java/julianh06/wynnextras/features/bankoverlay/BankOverlay2.java
@@ -1785,7 +1785,7 @@ public class BankOverlay2 extends WEHandledScreen {
 
             Pages.BankPageNames.put(index, pageName);
 
-            textInputWidget.setTextColor((activeInv == index && !shouldWait) ? CustomColor.fromHexString("FFEA00") : CustomColor.fromHexString("FFFFFF"));
+            textInputWidget.setTextColor((activeInv == index && !shouldWait) ? CustomColor.fromHexString("DEC800") : CustomColor.fromHexString("FFFFFF"));
             textInputWidget.setBounds(x, y, width, height);
             textInputWidget.setInput(pageName);
             textInputWidget.draw(ctx, mouseX, mouseY, tickDelta, ui);


### PR DESCRIPTION
fixed the bottom of the last row of pages being cut off more the more rows being rendered
fixed button background temporarily rendering at the wrong location when swapping bank types with more than 3 columns (should also fix emerald pouch overlay rendering position which i think i broke when adding support for more columns)
fixed rendering entirely empty rows for no reason
fixed the name of the selected page's shadow bobbing up and down (idk if this should be reported to wynntills or mojang but color should NOT be affecting position)