### PR TITLE
Fix NPE crash in RaidChatNotifier when getCurrentRaid() returns null

### DIFF
--- a/src/main/java/julianh06/wynnextras/features/chat/RaidChatNotifier.java
+++ b/src/main/java/julianh06/wynnextras/features/chat/RaidChatNotifier.java
@@ -437,7 +437,11 @@ public class RaidChatNotifier {
 
         @Override
         public String getFormattedMessage(String progress, String timestamp) {
-            long currentMillis = Models.Raid.getCurrentRaid().getCurrentRoom().getRoomTotalTime();
+            var raid = Models.Raid.getCurrentRaid();
+            if (raid == null || raid.getCurrentRoom() == null) {
+                return "§bCompleted Seal " + progress + " §c@ " + timestamp;
+            }
+            long currentMillis = raid.getCurrentRoom().getRoomTotalTime();
 
             String key = PB_PREFIX + "_" + progress;
             Long pb = getPB(key);
@@ -477,7 +481,11 @@ public class RaidChatNotifier {
 
         @Override
         public String getFormattedMessage(String progress, String timestamp) {
-            long currentMillis = Models.Raid.getCurrentRaid().getCurrentRoom().getRoomTotalTime();
+            var raid = Models.Raid.getCurrentRaid();
+            if (raid == null || raid.getCurrentRoom() == null) {
+                return "§bAdded light " + progress + " §c@ " + timestamp;
+            }
+            long currentMillis = raid.getCurrentRoom().getRoomTotalTime();
             String key = PB_PREFIX + "_" + progress;
 
             Long pb = getPB(key);
@@ -518,11 +526,15 @@ public class RaidChatNotifier {
 
         @Override
         public String getFormattedMessage(String progress, String timestamp) {
-            long currentMillis = Models.Raid.getCurrentRaid().getCurrentRoom().getRoomTotalTime();
-
             if ("3/3".equals(progress) && Time.now().timestamp() >= disableChiropUntil && WynnExtrasConfig.INSTANCE.chiropTimer) {
                 startSpawnCountdown();
             }
+
+            var raid = Models.Raid.getCurrentRaid();
+            if (raid == null || raid.getCurrentRoom() == null) {
+                return "§bKilled Shadowling " + progress + " §c@ " + timestamp;
+            }
+            long currentMillis = raid.getCurrentRoom().getRoomTotalTime();
 
             String key = PB_PREFIX + "_" + progress;
             Long pb = getPB(key);


### PR DESCRIPTION
## Summary

Three detectors in `RaidChatNotifier` (`SealCompletionDetector`, `LightGatheringDetector`, `ShadowlingDetector`) called `Models.Raid.getCurrentRaid().getCurrentRoom().getRoomTotalTime()` without a null guard. If the message arrives while the raid model briefly has no current raid (race on entry/exit), this NPEs and disconnects the player.

Other detectors in the same file already null-guard the same call — these three were missed. Fix mirrors the existing pattern: if raid/room is null, return the message without PB tracking.

## Diff

16 additions, 4 deletions across one file (`features/chat/RaidChatNotifier.java`).

## Test plan
- [x] Build passes
- Crash repro path: receive a `Shadowling has been killed!` / `Completed Seal` / `Light Crystals to the tower` message while `Models.Raid.getCurrentRaid()` is null → no longer crashes, message prints with timestamp but without PB note.