### PR TITLE
feat: Add new raid drop related functions

### DIFF
--- a/src/main/java/julianh06/wynnextras/features/raid/RaidLootData.java
+++ b/src/main/java/julianh06/wynnextras/features/raid/RaidLootData.java
@@ -127,6 +127,29 @@ public class RaidLootData {
         if (sessionPerRaidData != null) sessionPerRaidData.remove(raidName);
     }
 
+    public static RaidLootData.RaidSpecificLoot createAggregateData(RaidLootData data) {
+        RaidLootData.RaidSpecificLoot agg = new RaidLootData.RaidSpecificLoot();
+        agg.emeraldBlocks = data.emeraldBlocks;
+        agg.liquidEmeralds = data.liquidEmeralds;
+        agg.amplifierTier1 = data.amplifierTier1;
+        agg.amplifierTier2 = data.amplifierTier2;
+        agg.amplifierTier3 = data.amplifierTier3;
+        agg.amplifierTier4 = data.amplifierTier4;
+        agg.totalBags = data.totalBags;
+        agg.stuffedBags = data.stuffedBags;
+        agg.packedBags = data.packedBags;
+        agg.variedBags = data.variedBags;
+        agg.totalTomes = data.totalTomes;
+        agg.mythicTomes = data.mythicTomes;
+        agg.fabledTomes = data.fabledTomes;
+        agg.totalCharms = data.totalCharms;
+        agg.totalWards = data.totalWards;
+        agg.mythicAspects = data.mythicAspects;
+        agg.fabledAspects = data.fabledAspects;
+        agg.legendaryAspects = data.legendaryAspects;
+        return agg;
+    }
+
     public static class RaidSpecificLoot {
         public long emeraldBlocks = 0;
         public long liquidEmeralds = 0;

--- a/src/main/java/julianh06/wynnextras/features/raid/RaidLootTrackerOverlay.java
+++ b/src/main/java/julianh06/wynnextras/features/raid/RaidLootTrackerOverlay.java
@@ -269,7 +269,7 @@ public class RaidLootTrackerOverlay {
                     displayData = data.sessionData;
                     completions = data.sessionData.completionCount;
                 } else {
-                    displayData = createAggregateData(data);
+                    displayData = RaidLootData.createAggregateData(data);
                     completions = data.perRaidData.values().stream().mapToInt(r -> r.completionCount).sum();
                 }
             } else {
@@ -339,28 +339,6 @@ public class RaidLootTrackerOverlay {
         }
     }
 
-    private static RaidLootData.RaidSpecificLoot createAggregateData(RaidLootData data) {
-        RaidLootData.RaidSpecificLoot agg = new RaidLootData.RaidSpecificLoot();
-        agg.emeraldBlocks = data.emeraldBlocks;
-        agg.liquidEmeralds = data.liquidEmeralds;
-        agg.amplifierTier1 = data.amplifierTier1;
-        agg.amplifierTier2 = data.amplifierTier2;
-        agg.amplifierTier3 = data.amplifierTier3;
-        agg.amplifierTier4 = data.amplifierTier4;
-        agg.totalBags = data.totalBags;
-        agg.stuffedBags = data.stuffedBags;
-        agg.packedBags = data.packedBags;
-        agg.variedBags = data.variedBags;
-        agg.totalTomes = data.totalTomes;
-        agg.mythicTomes = data.mythicTomes;
-        agg.fabledTomes = data.fabledTomes;
-        agg.totalCharms = data.totalCharms;
-        agg.totalWards = data.totalWards;
-        agg.mythicAspects = data.mythicAspects;
-        agg.fabledAspects = data.fabledAspects;
-        agg.legendaryAspects = data.legendaryAspects;
-        return agg;
-    }
 
     private static int drawLine(DrawContext context, String lineId, String label, String value,
                                 CustomColor color, int y, boolean inInventory) {
@@ -410,7 +388,7 @@ public class RaidLootTrackerOverlay {
                 d = data.sessionData;
                 completions = data.sessionData.completionCount;
             } else {
-                d = createAggregateData(data);
+                d = RaidLootData.createAggregateData(data);
                 completions = data.perRaidData.values().stream().mapToInt(r -> r.completionCount).sum();
             }
         } else {

--- a/src/main/java/julianh06/wynnextras/functions/RaidFunctions.java
+++ b/src/main/java/julianh06/wynnextras/functions/RaidFunctions.java
@@ -1,0 +1,146 @@
+package julianh06.wynnextras.functions;
+
+import com.wynntils.core.consumers.functions.arguments.Argument;
+import com.wynntils.core.consumers.functions.arguments.FunctionArguments;
+import julianh06.wynnextras.features.raid.RaidLootConfig;
+import julianh06.wynnextras.features.raid.RaidLootData;
+import net.minecraft.client.resource.language.I18n;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+public class RaidFunctions {
+    private enum TYPE {
+        AMPLIFIER1,
+        AMPLIFIER2,
+        AMPLIFIER3,
+        AMPLIFIER4,
+        TOTAL_AMPLIFIER,
+        CHARMS,
+        EMERALDS,
+        FABLED_ASPECTS,
+        FABLED_TOMES,
+        LEGENDARY_ASPECTS,
+        MYTHIC_ASPECTS,
+        MYTHIC_TOMES,
+        PACKED_BAGS,
+        STUFFED_BAGS,
+        TOTAL_ASPECTS,
+        TOTAL_BAGS,
+        TOTAL_TOMES,
+        VARIED_BAGS,
+        WARDS;
+
+        static TYPE fromString(String name){
+            try {
+                return valueOf(name.toUpperCase(Locale.ROOT).replace(' ', '_'));
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+        }
+    }
+    private enum RAID {
+        ALL,
+        NOTG,
+        NOL,
+        TCC,
+        TNA,
+        TWP;
+
+        static RAID fromString(String name){
+            try {
+                return valueOf(name.toUpperCase(Locale.ROOT).replace(' ', '_'));
+            } catch (IllegalArgumentException e) {
+                return ALL;
+            }
+        }
+    }
+    private enum MODE{
+        ALL,
+        SESSION,
+        LATEST;
+
+        static MODE fromString(String name){
+            try {
+                return valueOf(name.toUpperCase(Locale.ROOT).replace(' ', '_'));
+            } catch (IllegalArgumentException e) {
+                return ALL;
+            }
+        }
+    }
+
+    public static class RaidDropFunction extends WEFunctionBase<Integer>{
+
+        @Override
+        public Integer getValue(FunctionArguments functionArguments) {
+            RAID raid = RAID.fromString(functionArguments.getArgument("raid").getStringValue());
+            MODE mode = MODE.fromString(functionArguments.getArgument("mode").getStringValue());
+            TYPE type = TYPE.fromString(functionArguments.getArgument("type").getStringValue());
+            RaidLootData data = RaidLootConfig.INSTANCE.data;
+            RaidLootData.RaidSpecificLoot selectedData;
+
+            if (mode == MODE.LATEST){
+                selectedData = data.latestData;
+            } else {
+                if (Objects.requireNonNull(raid) == RAID.ALL) {
+                    if (mode == MODE.SESSION) {
+                        selectedData = data.sessionData;
+                    } else {
+                        selectedData = RaidLootData.createAggregateData(data);
+                    }
+                } else {
+                    if (mode == MODE.SESSION) {
+                        selectedData = data.sessionPerRaidData != null ?
+                                data.sessionPerRaidData.getOrDefault(raid.name(), new RaidLootData.RaidSpecificLoot()) :
+                                new RaidLootData.RaidSpecificLoot();
+                    } else {
+                        selectedData = data.perRaidData.getOrDefault(raid.name(), new RaidLootData.RaidSpecificLoot());
+                    }
+                }
+            }
+
+            return (int) switch (type){
+                case AMPLIFIER1 -> selectedData.amplifierTier1;
+                case AMPLIFIER2 -> selectedData.amplifierTier2;
+                case AMPLIFIER3 -> selectedData.amplifierTier3;
+                case AMPLIFIER4 -> selectedData.amplifierTier4;
+                case TOTAL_AMPLIFIER -> selectedData.amplifierTier1 + selectedData.amplifierTier2 + selectedData.amplifierTier3 + selectedData.amplifierTier4;
+                case CHARMS -> selectedData.totalCharms;
+                case EMERALDS -> selectedData.liquidEmeralds * 64 * 64 + selectedData.emeraldBlocks * 64;
+                case FABLED_ASPECTS -> selectedData.fabledAspects;
+                case FABLED_TOMES -> selectedData.fabledTomes;
+                case LEGENDARY_ASPECTS -> selectedData.legendaryAspects;
+                case MYTHIC_ASPECTS -> selectedData.mythicAspects;
+                case MYTHIC_TOMES -> selectedData.mythicTomes;
+                case PACKED_BAGS -> selectedData.packedBags;
+                case STUFFED_BAGS -> selectedData.stuffedBags;
+                case TOTAL_ASPECTS -> selectedData.legendaryAspects + selectedData.fabledAspects + selectedData.mythicAspects;
+                case TOTAL_BAGS -> selectedData.packedBags + selectedData.variedBags + selectedData.stuffedBags;
+                case TOTAL_TOMES -> selectedData.fabledTomes + selectedData.mythicTomes;
+                case VARIED_BAGS -> selectedData.variedBags;
+                case WARDS -> selectedData.totalWards;
+                case null, default -> -1;
+            };
+        }
+
+        @Override
+        public FunctionArguments.Builder getArgumentsBuilder() {
+            return new FunctionArguments.RequiredArgumentBuilder(List.of(
+                    new Argument("raid", String.class, null),
+                    new Argument("mode", String.class, null),
+                    new Argument("type", String.class, null)
+            ));
+        }
+
+        @Override
+        public String getTranslation(String keySuffix, Object... parameters) {
+            return I18n.translate(this.getTypeName().toLowerCase(Locale.ROOT) + ".wynnextras." + this.getTranslationKeyName() + "." + keySuffix, new Object[]{
+                    String.join(", ", Arrays.stream(RAID.values()).map(Enum::name).sorted().toList()),
+                    String.join(", ", Arrays.stream(MODE.values()).map(Enum::name).sorted().toList()),
+                    String.join(", ", Arrays.stream(TYPE.values()).map(Enum::name).sorted().toList())
+            });
+        }
+    }
+}

--- a/src/main/java/julianh06/wynnextras/functions/RaidFunctions.java
+++ b/src/main/java/julianh06/wynnextras/functions/RaidFunctions.java
@@ -71,14 +71,15 @@ public class RaidFunctions {
         }
     }
 
-    public static class RaidDropFunction extends WEFunctionBase<Integer>{
+    public static class RaidDropFunction extends WEFunctionBase<Long>{
 
         @Override
-        public Integer getValue(FunctionArguments functionArguments) {
+        public Long getValue(FunctionArguments functionArguments) {
             RAID raid = RAID.fromString(functionArguments.getArgument("raid").getStringValue());
             MODE mode = MODE.fromString(functionArguments.getArgument("mode").getStringValue());
             TYPE type = TYPE.fromString(functionArguments.getArgument("type").getStringValue());
             RaidLootData data = RaidLootConfig.INSTANCE.data;
+            data.initSession();
             RaidLootData.RaidSpecificLoot selectedData;
 
             if (mode == MODE.LATEST){
@@ -101,27 +102,27 @@ public class RaidFunctions {
                 }
             }
 
-            return (int) switch (type){
-                case AMPLIFIER1 -> selectedData.amplifierTier1;
-                case AMPLIFIER2 -> selectedData.amplifierTier2;
-                case AMPLIFIER3 -> selectedData.amplifierTier3;
-                case AMPLIFIER4 -> selectedData.amplifierTier4;
-                case TOTAL_AMPLIFIER -> selectedData.amplifierTier1 + selectedData.amplifierTier2 + selectedData.amplifierTier3 + selectedData.amplifierTier4;
-                case CHARMS -> selectedData.totalCharms;
-                case EMERALDS -> selectedData.liquidEmeralds * 64 * 64 + selectedData.emeraldBlocks * 64;
-                case FABLED_ASPECTS -> selectedData.fabledAspects;
-                case FABLED_TOMES -> selectedData.fabledTomes;
-                case LEGENDARY_ASPECTS -> selectedData.legendaryAspects;
-                case MYTHIC_ASPECTS -> selectedData.mythicAspects;
-                case MYTHIC_TOMES -> selectedData.mythicTomes;
-                case PACKED_BAGS -> selectedData.packedBags;
-                case STUFFED_BAGS -> selectedData.stuffedBags;
-                case TOTAL_ASPECTS -> selectedData.legendaryAspects + selectedData.fabledAspects + selectedData.mythicAspects;
-                case TOTAL_BAGS -> selectedData.packedBags + selectedData.variedBags + selectedData.stuffedBags;
-                case TOTAL_TOMES -> selectedData.fabledTomes + selectedData.mythicTomes;
-                case VARIED_BAGS -> selectedData.variedBags;
-                case WARDS -> selectedData.totalWards;
-                case null, default -> -1;
+            return switch (type){
+                case AMPLIFIER1 -> (long) selectedData.amplifierTier1;
+                case AMPLIFIER2 -> (long) selectedData.amplifierTier2;
+                case AMPLIFIER3 -> (long) selectedData.amplifierTier3;
+                case AMPLIFIER4 -> (long) selectedData.amplifierTier4;
+                case TOTAL_AMPLIFIER -> (long) selectedData.amplifierTier1 + selectedData.amplifierTier2 + selectedData.amplifierTier3 + selectedData.amplifierTier4;
+                case CHARMS -> (long) selectedData.totalCharms;
+                case EMERALDS -> selectedData.liquidEmeralds * 64L * 64L + selectedData.emeraldBlocks * 64L;
+                case FABLED_ASPECTS -> (long) selectedData.fabledAspects;
+                case FABLED_TOMES -> (long) selectedData.fabledTomes;
+                case LEGENDARY_ASPECTS -> (long) selectedData.legendaryAspects;
+                case MYTHIC_ASPECTS -> (long) selectedData.mythicAspects;
+                case MYTHIC_TOMES -> (long) selectedData.mythicTomes;
+                case PACKED_BAGS -> (long) selectedData.packedBags;
+                case STUFFED_BAGS -> (long) selectedData.stuffedBags;
+                case TOTAL_ASPECTS -> (long) selectedData.legendaryAspects + selectedData.fabledAspects + selectedData.mythicAspects;
+                case TOTAL_BAGS -> (long) selectedData.packedBags + selectedData.variedBags + selectedData.stuffedBags;
+                case TOTAL_TOMES -> (long) selectedData.fabledTomes + selectedData.mythicTomes;
+                case VARIED_BAGS -> (long) selectedData.variedBags;
+                case WARDS -> (long) selectedData.totalWards;
+                case null, default -> -1L;
             };
         }
 

--- a/src/main/java/julianh06/wynnextras/functions/WEFunctionBase.java
+++ b/src/main/java/julianh06/wynnextras/functions/WEFunctionBase.java
@@ -1,0 +1,24 @@
+package julianh06.wynnextras.functions;
+
+import com.google.common.base.CaseFormat;
+import com.wynntils.core.consumers.functions.Function;
+
+public abstract class WEFunctionBase<T> extends Function<T> {
+    private final String WEName;
+
+    protected WEFunctionBase(){
+        String name = this.getClass().getSimpleName().replace("Function", "");
+        WEName = "wynnextras_" + CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, name);
+    }
+
+    @Override
+    public String getTypeName() {
+        return "WynnExtrasFunction";
+    }
+
+    @Override
+    public String getName() {
+        return this.WEName;
+    }
+}
+

--- a/src/main/java/julianh06/wynnextras/mixin/FunctionManagerMixin.java
+++ b/src/main/java/julianh06/wynnextras/mixin/FunctionManagerMixin.java
@@ -1,0 +1,21 @@
+package julianh06.wynnextras.mixin;
+
+import com.wynntils.core.consumers.functions.Function;
+import com.wynntils.core.consumers.functions.FunctionManager;
+import julianh06.wynnextras.functions.RaidFunctions;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = FunctionManager.class, remap = false)
+public abstract class FunctionManagerMixin {
+    @Shadow
+    protected abstract void registerFunction(Function<?> function);
+
+    @Inject(method = "registerAllFunctions()V", at = @At("TAIL"))
+    private void registerWEFunctions(CallbackInfo ci){
+        registerFunction(new RaidFunctions.RaidDropFunction());
+    }
+}

--- a/src/main/resources/assets/wynnextras/lang/en_us.json
+++ b/src/main/resources/assets/wynnextras/lang/en_us.json
@@ -1,0 +1,7 @@
+{
+  "wynnextrasfunction.wynnextras.raidDropFunction.name": "Raid Drops",
+  "wynnextrasfunction.wynnextras.raidDropFunction.description": "Returns your raid drops by specified filters",
+  "wynnextrasfunction.wynnextras.raidDropFunction.argument.raid": "Available values: %1$s",
+  "wynnextrasfunction.wynnextras.raidDropFunction.argument.mode": "Available values: %2$s",
+  "wynnextrasfunction.wynnextras.raidDropFunction.argument.type": "Available values: %3$s"
+}

--- a/src/main/resources/wynnextras.mixins.json
+++ b/src/main/resources/wynnextras.mixins.json
@@ -42,7 +42,7 @@
   "mixins": [
     "CharacterModelMixin",
     "ChatScreenMixin",
-    "Accessor.EventAccessor",
+    "FunctionManagerMixin",
     "ItemFavoriteFeatureAccessor",
     "ItemGuessFeatureAccessor",
     "ItemStatInfoFeatureMixin",
@@ -56,6 +56,7 @@
     "Accessor.BannerBlockEntityAccessor",
     "Accessor.BossBarHudAccessor",
     "Accessor.ChatHudAccessor",
+    "Accessor.EventAccessor",
     "Accessor.InGameHudAccessor",
     "Accessor.PersonalStorageUtilitiesFeatureAccessor",
     "Accessor.SlotAccessor",


### PR DESCRIPTION
First time for me and maybe even for Wynntils as a whole where a new function is added into a separate mod.

This PR adds a new function that fetches raid drop info, allowing users to make their own cool displays. This required a few stuff to change in order to make code more readable, additionally a language file was needed for Wynntils to work, honestly personally kinda surprised there wasn't one already. I implemented it in a way that users can filter by pretty much anything so they can recreate the standard Wynnextras display, as well as made it in such a way that adding new functions should be fairly easy.

<img width="1303" height="504" alt="image" src="https://github.com/user-attachments/assets/f679e7db-75f4-4522-8f7d-863960e33411" />
<img width="2560" height="1417" alt="image" src="https://github.com/user-attachments/assets/fddc8ed8-182f-4d27-8442-cd401e3cfbca" />

Important: I couldn't test everything, didn't test Session and Latest drops, as well as didn't test filtering for TNA and TWP as I never completed these raids