### PR TITLE
Add /we record — raw game data recorder

### DIFF
--- a/src/main/java/julianh06/wynnextras/core/WynnExtras.java
+++ b/src/main/java/julianh06/wynnextras/core/WynnExtras.java
@@ -215,6 +215,7 @@ public class WynnExtras implements ClientModInitializer {
         julianh06.wynnextras.features.qol.AutoSkipCutscenes.register();
         julianh06.wynnextras.features.chat.ChainsAttachedTracker.register();
         julianh06.wynnextras.features.qol.AuraPing.register();
+        julianh06.wynnextras.features.debug.GameDataRecorder.register();
         julianh06.wynnextras.features.qol.WeeklyWarCount.register();
         julianh06.wynnextras.features.qol.WarDPS.register();
         julianh06.wynnextras.features.qol.AttackTimer.register();

--- a/src/main/java/julianh06/wynnextras/core/loader/CommandLoader.java
+++ b/src/main/java/julianh06/wynnextras/core/loader/CommandLoader.java
@@ -137,6 +137,15 @@ public class CommandLoader implements WELoader {
             base = base.then(bombshare);
             alias = alias.then(bombshare);
 
+            var record = ClientCommandManager.literal("record")
+                    .executes(ctx -> {
+                        McUtils.sendMessageToClient(WynnExtras.addWynnExtrasPrefix(
+                                julianh06.wynnextras.features.debug.GameDataRecorder.toggle()));
+                        return 1;
+                    });
+            base = base.then(record);
+            alias = alias.then(record);
+
             var hide = ClientCommandManager.literal("hide")
                     .executes(ctx -> {
                         WynnExtrasConfig.INSTANCE.playerHiderToggle = !WynnExtrasConfig.INSTANCE.playerHiderToggle;

--- a/src/main/java/julianh06/wynnextras/features/debug/GameDataRecorder.java
+++ b/src/main/java/julianh06/wynnextras/features/debug/GameDataRecorder.java
@@ -1,0 +1,123 @@
+package julianh06.wynnextras.features.debug;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.mojang.serialization.JsonOps;
+import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.text.Text;
+import net.minecraft.text.TextCodecs;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Records raw game data (titles, scoreboard lines, chat, action bar, boss bars,
+ * container titles) into a JSONL file while enabled. Toggled with /we record.
+ *
+ * Purpose: collect real Wynncraft protocol samples so detection patterns
+ * (raids, world state, chat types, ...) can be built and tested against
+ * actual captured data instead of guesswork.
+ */
+public class GameDataRecorder {
+    private static final DateTimeFormatter FILE_STAMP = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss");
+
+    private static boolean enabled = false;
+    private static BufferedWriter writer = null;
+    private static Path currentFile = null;
+    private static int lineCount = 0;
+
+    public static void register() {
+        // Chat + action bar arrive through Fabric's message events; everything
+        // packet-shaped (titles, scoreboard, boss bars, container titles) is fed
+        // by GameDataRecorderMixin. Recording never alters the message flow.
+        ClientReceiveMessageEvents.ALLOW_GAME.register((message, overlay) -> {
+            record(overlay ? "actionbar" : "chat", message);
+            return true;
+        });
+    }
+
+    public static boolean isEnabled() {
+        return enabled;
+    }
+
+    public static String toggle() {
+        if (enabled) {
+            close();
+            return "§cRecording stopped§7 — " + lineCount + " entries in " + currentFile.getFileName();
+        }
+        try {
+            Path dir = FabricLoader.getInstance().getGameDir().resolve("wynnextras").resolve("capture");
+            Files.createDirectories(dir);
+            currentFile = dir.resolve("capture-" + LocalDateTime.now().format(FILE_STAMP) + ".jsonl");
+            writer = Files.newBufferedWriter(currentFile, StandardCharsets.UTF_8);
+            lineCount = 0;
+            enabled = true;
+            return "§aRecording game data§7 to " + currentFile.getFileName() + " — run §f/we record§7 again to stop.";
+        } catch (IOException e) {
+            return "§cCouldn't start recording: " + e.getMessage();
+        }
+    }
+
+    public static void record(String type, Text text, String... extraKeyValues) {
+        if (!enabled || text == null) return;
+
+        JsonObject entry = new JsonObject();
+        entry.addProperty("t", System.currentTimeMillis());
+        entry.addProperty("type", type);
+        entry.addProperty("plain", text.getString());
+        // Full component JSON keeps colors/fonts/hover data that getString() drops —
+        // Wynncraft encodes a lot of meaning in styling, so patterns need it.
+        try {
+            TextCodecs.CODEC.encodeStart(JsonOps.INSTANCE, text)
+                    .result()
+                    .ifPresent(json -> entry.add("json", json));
+        } catch (Exception ignored) {} // some hover payloads need registry context; plain text is still recorded
+        addExtras(entry, extraKeyValues);
+        write(entry);
+    }
+
+    public static void recordRaw(String type, String value, String... extraKeyValues) {
+        if (!enabled || value == null) return;
+
+        JsonObject entry = new JsonObject();
+        entry.addProperty("t", System.currentTimeMillis());
+        entry.addProperty("type", type);
+        entry.addProperty("plain", value);
+        addExtras(entry, extraKeyValues);
+        write(entry);
+    }
+
+    private static void addExtras(JsonObject entry, String... extraKeyValues) {
+        for (int i = 0; i + 1 < extraKeyValues.length; i += 2) {
+            entry.addProperty(extraKeyValues[i], extraKeyValues[i + 1]);
+        }
+    }
+
+    private static synchronized void write(JsonObject entry) {
+        if (writer == null) return;
+        try {
+            writer.write(entry.toString());
+            writer.newLine();
+            writer.flush();
+            lineCount++;
+        } catch (IOException e) {
+            close();
+        }
+    }
+
+    private static synchronized void close() {
+        enabled = false;
+        if (writer != null) {
+            try {
+                writer.close();
+            } catch (IOException ignored) {}
+            writer = null;
+        }
+    }
+}

--- a/src/main/java/julianh06/wynnextras/mixin/GameDataRecorderMixin.java
+++ b/src/main/java/julianh06/wynnextras/mixin/GameDataRecorderMixin.java
@@ -1,0 +1,101 @@
+package julianh06.wynnextras.mixin;
+
+import java.util.UUID;
+import julianh06.wynnextras.features.debug.GameDataRecorder;
+import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.entity.boss.BossBar;
+import net.minecraft.network.packet.s2c.play.BossBarS2CPacket;
+import net.minecraft.network.packet.s2c.play.OpenScreenS2CPacket;
+import net.minecraft.network.packet.s2c.play.ScoreboardDisplayS2CPacket;
+import net.minecraft.network.packet.s2c.play.ScoreboardObjectiveUpdateS2CPacket;
+import net.minecraft.network.packet.s2c.play.ScoreboardScoreResetS2CPacket;
+import net.minecraft.network.packet.s2c.play.ScoreboardScoreUpdateS2CPacket;
+import net.minecraft.network.packet.s2c.play.SubtitleS2CPacket;
+import net.minecraft.network.packet.s2c.play.TitleS2CPacket;
+import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Feeds the /we record capture file with the packet-shaped data the chat events
+ * can't see: titles, scoreboard updates, boss bars and container titles.
+ * Read-only taps at RETURN — vanilla handling is never altered.
+ */
+@Mixin(ClientPlayNetworkHandler.class)
+public class GameDataRecorderMixin {
+    @Inject(method = "onTitle(Lnet/minecraft/network/packet/s2c/play/TitleS2CPacket;)V", at = @At("RETURN"))
+    private void wynnextras$recordTitle(TitleS2CPacket packet, CallbackInfo ci) {
+        GameDataRecorder.record("title", packet.text());
+    }
+
+    @Inject(method = "onSubtitle(Lnet/minecraft/network/packet/s2c/play/SubtitleS2CPacket;)V", at = @At("RETURN"))
+    private void wynnextras$recordSubtitle(SubtitleS2CPacket packet, CallbackInfo ci) {
+        GameDataRecorder.record("subtitle", packet.text());
+    }
+
+    @Inject(
+            method = "onScoreboardScoreUpdate(Lnet/minecraft/network/packet/s2c/play/ScoreboardScoreUpdateS2CPacket;)V",
+            at = @At("RETURN"))
+    private void wynnextras$recordScoreSet(ScoreboardScoreUpdateS2CPacket packet, CallbackInfo ci) {
+        if (!GameDataRecorder.isEnabled()) return;
+        GameDataRecorder.recordRaw("scoreboard_set", packet.scoreHolderName(),
+                "objective", packet.objectiveName(), "score", String.valueOf(packet.score()));
+        packet.display().ifPresent(display -> GameDataRecorder.record("scoreboard_set_display", display,
+                "objective", packet.objectiveName()));
+    }
+
+    @Inject(
+            method = "onScoreboardScoreReset(Lnet/minecraft/network/packet/s2c/play/ScoreboardScoreResetS2CPacket;)V",
+            at = @At("RETURN"))
+    private void wynnextras$recordScoreReset(ScoreboardScoreResetS2CPacket packet, CallbackInfo ci) {
+        GameDataRecorder.recordRaw("scoreboard_reset", packet.scoreHolderName(),
+                "objective", String.valueOf(packet.objectiveName()));
+    }
+
+    @Inject(
+            method =
+                    "onScoreboardObjectiveUpdate(Lnet/minecraft/network/packet/s2c/play/ScoreboardObjectiveUpdateS2CPacket;)V",
+            at = @At("RETURN"))
+    private void wynnextras$recordObjective(ScoreboardObjectiveUpdateS2CPacket packet, CallbackInfo ci) {
+        GameDataRecorder.record("scoreboard_objective", packet.getDisplayName(),
+                "name", packet.getName(), "mode", String.valueOf(packet.getMode()));
+    }
+
+    @Inject(
+            method = "onScoreboardDisplay(Lnet/minecraft/network/packet/s2c/play/ScoreboardDisplayS2CPacket;)V",
+            at = @At("RETURN"))
+    private void wynnextras$recordScoreboardDisplay(ScoreboardDisplayS2CPacket packet, CallbackInfo ci) {
+        GameDataRecorder.recordRaw("scoreboard_display", String.valueOf(packet.getName()),
+                "slot", String.valueOf(packet.getSlot()));
+    }
+
+    @Inject(method = "onOpenScreen(Lnet/minecraft/network/packet/s2c/play/OpenScreenS2CPacket;)V", at = @At("RETURN"))
+    private void wynnextras$recordContainerTitle(OpenScreenS2CPacket packet, CallbackInfo ci) {
+        GameDataRecorder.record("container_title", packet.getName(),
+                "syncId", String.valueOf(packet.getSyncId()));
+    }
+
+    @Inject(method = "onBossBar(Lnet/minecraft/network/packet/s2c/play/BossBarS2CPacket;)V", at = @At("RETURN"))
+    private void wynnextras$recordBossBar(BossBarS2CPacket packet, CallbackInfo ci) {
+        if (!GameDataRecorder.isEnabled()) return;
+        packet.accept(new BossBarS2CPacket.Consumer() {
+            @Override
+            public void add(UUID uuid, Text name, float percent, BossBar.Color color, BossBar.Style style,
+                            boolean darkenSky, boolean dragonMusic, boolean thickenFog) {
+                GameDataRecorder.record("bossbar_add", name, "percent", String.valueOf(percent));
+            }
+
+            @Override
+            public void updateName(UUID uuid, Text name) {
+                GameDataRecorder.record("bossbar_name", name);
+            }
+
+            @Override
+            public void updateProgress(UUID uuid, float percent) {
+                GameDataRecorder.recordRaw("bossbar_progress", String.valueOf(percent));
+            }
+        });
+    }
+}

--- a/src/main/resources/wynnextras.mixins.json
+++ b/src/main/resources/wynnextras.mixins.json
@@ -15,6 +15,7 @@
     "ChatHudAddMessageMixin",
     "ClientPlayerInteractionManagerMixin",
     "ClientPacketListenerMixin",
+    "GameDataRecorderMixin",
     "EntityRenderMixin",
     "GameRendererMixin",
     "GuildMapScreenMixin",


### PR DESCRIPTION
adds `/we record`: dumps raw titles, scoreboard lines, boss bars, container titles, chat and action bar to a jsonl file while enabled (plain string + full component json). read-only taps, off by default, own code.

groundwork for building our own detection patterns from real captured data — first step towards not needing wynntils for the data layer, as discussed.